### PR TITLE
Odorant page: list indicates receptors w/o sufficient data.

### DIFF
--- a/www/assets/style.css
+++ b/www/assets/style.css
@@ -20,6 +20,11 @@ body
     text-shadow: 0px 0px 5px #0cf;
 }
 
+.dim
+{
+    color: #8b8494;
+}
+
 ::-webkit-scrollbar 
 {
     width: 13px;

--- a/www/odorant.php
+++ b/www/odorant.php
@@ -258,7 +258,14 @@ foreach (array_keys($sorted) as $rcpid)
     else echo "<td>&nbsp;</td>";
 
     if (@$agonist[$rcpid])
-        echo "<td style=\"white-space: nowrap;\">" . substr(get_notes_for_receptor($rcpid, $correlations), 0, 123) . "</td>\n";
+    {
+        $notes = substr(get_notes_for_receptor($rcpid, $correlations), 0, 123);
+        if (substr($notes, 0, 1) == '(')
+        {
+            $notes = "<i class=\"dim\">$notes</i>";
+        }
+        echo "<td style=\"white-space: nowrap;\">$notes</td>\n";
+    }
     else
         echo "<td>&nbsp;</td>\n";
 

--- a/www/receptor_notes.php
+++ b/www/receptor_notes.php
@@ -22,8 +22,8 @@ function correlate_receptors_aromanotes()
     foreach (array_keys($prots) as $rcpid)
     {
         $ep = all_empirical_pairs_for_receptor($rcpid, true);
-        foreach ($ep as $k => $v) if ($v <= 0) unset($ep[$k]);
-        if (count($ep) < 3) continue;
+        // foreach ($ep as $k => $v) if ($v <= 0) unset($ep[$k]);
+        if (count($ep) < 2) continue;
 
         $xvals[$rcpid] = [];
         foreach ($odors as $oid => $odor)

--- a/www/receptor_notes.php
+++ b/www/receptor_notes.php
@@ -21,6 +21,10 @@ function correlate_receptors_aromanotes()
 
     foreach (array_keys($prots) as $rcpid)
     {
+        $ep = all_empirical_pairs_for_receptor($rcpid, true);
+        foreach ($ep as $k => $v) if ($v <= 0) unset($ep[$k]);
+        if (count($ep) < 3) continue;
+
         $xvals[$rcpid] = [];
         foreach ($odors as $oid => $odor)
         {
@@ -96,7 +100,7 @@ function correlate_receptors_aromanotes()
 
 function get_notes_for_receptor($rcpid, $correlations)
 {
-    if (!isset($correlations[$rcpid])) return "(none)";
+    if (!isset($correlations[$rcpid])) return "(insufficient data)";
 
     $maxcorr = floatval(max($correlations[$rcpid]));
     $threshold = $maxcorr / 2;


### PR DESCRIPTION
Receptors with less than two ligands of any activity level, or without any aroma note correlations meeting the cutoff threshold, will show as (insufficient data) in dim italic text instead of repeating notes from the current compound or just saying "none".

No changes to primarydock code.