### PR TITLE
Limit shielding allowances for pi bonds.

### DIFF
--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -262,6 +262,7 @@ public:
     float last_bind_energy = 0;
     float strongest_bind_energy = 0;
     Atom* strongest_bind_atom = nullptr;
+    float shielding_angle = 0;
 
     #if debug_break_on_move
     bool break_on_move = false;		// debugging feature.

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -56,6 +56,7 @@
 #define _def_atc 100
 #define _ALLOW_FLEX_RINGS 0
 #define _shield_angle (130.0 * fiftyseventh)
+#define _shield_angle_pi (100.0 * fiftyseventh)
 #define _can_clash_angle (120.0 * fiftyseventh)
 #define _fullrot_stepdeg 30
 #define _fullrot_steprad (fiftyseventh*_fullrot_stepdeg)

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -614,6 +614,8 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
         }
         else if (r1 > 4) continue;
 
+        if (forces[i]->type == pi && (a->shielding_angle >= _shield_angle_pi || b->shielding_angle >= _shield_angle_pi)) continue;
+
         dp = 2;
         if (forces[i]->type == vdW) dp = 1;					// van der Waals forces are non-directional, but the C-H bond still shields.
         else if (forces[i]->get_dp()) dp = forces[i]->get_dp();

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -1930,6 +1930,8 @@ bool Molecule::shielded(Atom* a, Atom* b) const
     float r6 = r*1.26, r125 = 1.25*r;
     if (r < 2) return false;
 
+    a->shielding_angle = b->shielding_angle = 0;
+
     Point aloc = a->get_location(), bloc = b->get_location();
     for (i=0; i<atcount; i++)
     {
@@ -1942,6 +1944,7 @@ bool Molecule::shielded(Atom* a, Atom* b) const
         if ((rai+rbi) > r125) continue;
         Point sloc = ai->get_location();
         float f3da = find_3d_angle(&aloc, &bloc, &sloc);
+        if (f3da > a->shielding_angle) a->shielding_angle = b->shielding_angle = f3da;
         if (f3da > _shield_angle)
         {
             if (last_iter && (a->residue == 114 || b->residue == 114) && ((a->residue + b->residue) == 114))

--- a/viewer.htm
+++ b/viewer.htm
@@ -1015,8 +1015,8 @@ var PODefScheme = NGL.ColormakerRegistry.addScheme(function (params)
                 return 0x666666;
             }
 
-        	case 'N': return born ? (atom.isBackbone() ? 0x660033 : 0xFF4444) : (atom.isBackbone() ? 0x000066 : 0x0066FF);
-        	case 'O': return born ? (atom.isBackbone() ? 0x003366 : 0x00BBFF) : (atom.isBackbone() ? 0x660000 : 0xFF0000);
+        	case 'N': return born ? (atom.isBackbone() ? 0x660033 : 0xCC3366) : (atom.isBackbone() ? 0x000066 : 0x0066FF);
+        	case 'O': return born ? (atom.isBackbone() ? 0x003366 : 0x0066FF) : (atom.isBackbone() ? 0x660000 : 0xFF0000);
         	case 'P': return 0xff77c6;
         	case 'S': return 0xffdd00;
         	case 'Se': return 0xffaa00;
@@ -1064,7 +1064,7 @@ var PODefSchemeHilite = NGL.ColormakerRegistry.addScheme(function (params)
                 case 'LEU':
                 case 'PRO':
                 case 'VAL':
-                return 0xbbbbbb;
+                return 0xbbccbb;
 
                 case 'MET':
                 case 'CYS':
@@ -1074,7 +1074,7 @@ var PODefSchemeHilite = NGL.ColormakerRegistry.addScheme(function (params)
                 case 'PHE':
                 case 'TRP':
                 case 'TYR':
-                return 0xaa77aa;
+                return 0xaa88aa;
 
                 case 'SER':
                 case 'THR':
@@ -1096,8 +1096,8 @@ var PODefSchemeHilite = NGL.ColormakerRegistry.addScheme(function (params)
                 return 0x777777;
             }
 
-        	case 'N': return born ? (atom.isBackbone() ? 0x660033 : 0xFF4444) : (atom.isBackbone() ? 0x000066 : 0x0087FF);
-        	case 'O': return born ? (atom.isBackbone() ? 0x003366 : 0x00bbFF) : (atom.isBackbone() ? 0x660000 : 0xFF2222);
+        	case 'N': return born ? (atom.isBackbone() ? 0x660033 : 0xCC3366) : (atom.isBackbone() ? 0x000066 : 0x0087FF);
+        	case 'O': return born ? (atom.isBackbone() ? 0x003366 : 0x0066FF) : (atom.isBackbone() ? 0x660000 : 0xFF2222);
         	case 'P': return 0xff8add;
         	case 'S': return 0xffe022;
         	case 'Se': return 0xffb022;
@@ -1133,8 +1133,8 @@ var PODefSchemeLigand = NGL.ColormakerRegistry.addScheme(function (params)
         {
         	case 'H': return 0xe1faff;
         	case 'C': return 0xa7ada4;
-        	case 'N': return born ? 0xFF4444 : 0x5555FF;
-        	case 'O': return born ? 0x00BBFF : 0xFF2222;
+        	case 'N': return born ? 0xCC3366 : 0x5555FF;
+        	case 'O': return born ? 0x0066FF : 0xFF2222;
         	case 'P': return 0xff8add;
         	case 'S': return 0xffe022;
         	case 'Se': return 0xffb022;


### PR DESCRIPTION
Currently, a potential interatomic interaction is considered shielded if the angle between the two atoms, relative to the shielding atom is >= 130deg. This PR has the effect of reducing this threshold to 100deg for pi bonds.

The shielded status is currently unfortunately all-or-nothing, with no accounting for partial shielding caused by partial eclipses of atoms. While this PR does not address that shortcoming, it does provide a new public Atom::shielding_angle property that contains the result of the most recent shielding check, that can be used inside the interaction class for partial shielding calculations.