### PR TITLE
Avoid moving side chains that are strongly bound in the original PDB.

### DIFF
--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -174,7 +174,7 @@
 // Switches whether the best-binding algorithm is active by default, instead of tumble spheres.
 #define default_bestbind 1
 #define preemptively_minimize_intermol_clashes 0
-#define bestbind_springiness 10
+#define bestbind_springiness 15
 
 // For differential docking, whether to multimol_conform() all the protein's residues into an
 // optimized initial conformation before adding the ligand.

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2346,7 +2346,7 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
             }
             mm[i]->lastbind = bind;
             fmaxb = maxb;
-            if (mm[i]->movability == MOV_NONE
+            if (mm[i]->movability == MOV_PINNED
                 &&
                 mm[i]->get_intermol_clashes(all) >= 1
                )

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2346,6 +2346,11 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
             }
             mm[i]->lastbind = bind;
             fmaxb = maxb;
+            if (mm[i]->movability == MOV_NONE
+                &&
+                mm[i]->get_intermol_clashes(all) >= 1
+               )
+                mm[i]->movability = MOV_FLEXONLY;               // TODO: Prevent this if molecule is a metal bound residue.
 
             float reversal = -0.666; // TODO: Make this binding-energy dependent.
             float accel = 1.1;

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -25,6 +25,7 @@ enum MovabilityType
     MOV_ALL			= 1000,
     MOV_NORECEN		=  200,
     MOV_FLEXONLY	=   50,
+    MOV_PINNED      =    1,
     MOV_NONE		=    0
 };
 

--- a/src/classes/protein.cpp
+++ b/src/classes/protein.cpp
@@ -238,15 +238,22 @@ void Protein::find_residue_initial_bindings()
         {
             for (j=0; aa[j]; j++)
             {
-                int ac = aa[j]->get_atom_count();
-                for (k=0; k<ac; k++)
+                Atom* a = residues[i]->get_nearest_atom(aa[j]->get_barycenter());
+                Atom* b = aa[j]->get_nearest_atom(a->get_location());
+                float r = a->distance_to(b);
+
+                if (r < 4)
                 {
-                    Atom* a = aa[j]->get_atom(k);
-                    if ( !a->is_backbone && a->get_family() == PNICTOGEN && !a->get_charge() )
+                    int ac = aa[j]->get_atom_count();
+                    for (k=0; k<ac; k++)
                     {
-                        Atom* C = a->is_bonded_to(TETREL, 1);
-                        if (C && C->is_bonded_to(CHALCOGEN, 2)) continue;
-                        else a->increment_charge(0.75);
+                        Atom* a = aa[j]->get_atom(k);
+                        if ( !a->is_backbone && a->get_family() == PNICTOGEN && !a->get_charge() )
+                        {
+                            Atom* C = a->is_bonded_to(TETREL, 1);
+                            if (C && C->is_bonded_to(CHALCOGEN, 2)) continue;
+                            else a->increment_charge(0.75);
+                        }
                     }
                 }
             }

--- a/src/classes/protein.cpp
+++ b/src/classes/protein.cpp
@@ -253,7 +253,7 @@ void Protein::find_residue_initial_bindings()
         }
 
         float ib = residues[i]->get_intermol_binding(aa);
-        if (ib >= 5) residues[i]->movability = MOV_NONE;
+        if (ib >= 5) residues[i]->movability = MOV_PINNED;
 
         #if _debug_locks
         if (residues[i]->get_residue_no() == _dbg_lock_res)

--- a/src/classes/protein.h
+++ b/src/classes/protein.h
@@ -98,6 +98,7 @@ public:
                          );
 
     void backconnect(int startres, int endres);
+    void find_residue_initial_bindings();
 
     void make_helix(int startres, int endres, float phi, float psi);
     void make_helix(int startres, int endres, int stopat, float phi, float psi);

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -2135,13 +2135,38 @@ _try_again:
                                 retain_bindings[l].btom = coi;
                                 retain_bindings[l].cardinality = 0.25;
                                 retain_bindings[l].type = lig_inter_typ[l];
+                                
+                                bool opml_known = false;
                                 try
                                 {
                                     retain_bindings[l].optimal_radius = InteratomicForce::coordinate_bond_radius(ligbb[l], coi, lig_inter_typ[l]);
+                                    retain_bindings[l].optimal_radius = InteratomicForce::coordinate_bond_radius(
+                                        retain_bindings[l].atom,
+                                        retain_bindings[l].btom,
+                                        retain_bindings[l].type
+                                        );
+                                    opml_known = true;
                                 }
                                 catch (int ex)
                                 {
                                     ;
+                                }
+                                if (!opml_known && ligbbh[l] && (retain_bindings[l].btom->get_Z() > 1 || retain_bindings[l].type == vdW))
+                                {
+                                    try
+                                    {
+                                        retain_bindings[l].optimal_radius = InteratomicForce::coordinate_bond_radius(
+                                            ligbbh[l],
+                                            retain_bindings[l].btom,
+                                            retain_bindings[l].type
+                                            );
+                                        retain_bindings[l].atom = ligbbh[l];
+                                        opml_known = true;
+                                    }
+                                    catch (int ex)
+                                    {
+                                        retain_bindings[l].optimal_radius = 2.5;
+                                    }
                                 }
 
                                 alignment_aa[l]->springy_bonds = retain_bindings;

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -2362,6 +2362,7 @@ _try_again:
             for (j=0; j<trsz; j++)
                 trip[j] = (Molecule*)protein->get_residue(tripswitch_clashables[j]);
 
+            protein->find_residue_initial_bindings();
             Molecule::multimol_conform(
                 cfmols,
                 delete_me = protein->all_residues_as_molecules(),


### PR DESCRIPTION
Mark strongly bound (< -5 kJ/mol) residue side chains as MOV_NONE unless clashing with the ligand. Also partially charge neutral, non-amide nitrogen in proximity to a negative charge. Also fix springy bond distances.

Currently testing Big 3. The OR1A1 test should reveal whether Asp111 stays salt bridged to His243.