### PR TITLE
Fix hard coded glycine check in primarydock.cpp

### DIFF
--- a/predict/bsrscan.php
+++ b/predict/bsrscan.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once("protutils.php");
+
+foreach (@$argv as $a)
+{
+	$a = explode('=',$a,2);
+	$_REQUEST[$a[0]] = (count($a)>1) ? $a[1] : true;
+}
+
+$search = @$_REQUEST['search'] ?: false;
+$result = [];
+foreach ($prots as $protid => $p)
+{
+    if (!isset($p['bw'])) continue;
+
+
+    $bsrs = binding_site($protid);
+    $string = "";
+    $count = 0;
+
+    foreach ($bsrs as $resno)
+    {
+        $c = substr($p['sequence'], $resno-1, 1);
+        $string .= $c;
+        if ($c == $search) $count++;
+    }
+    
+    $result[] = ($search ? "$count " : "").str_pad("$protid: ", 13).$string;
+}
+
+if ($search) natsort($result);
+echo implode("\n", $result)."\n";

--- a/primarydock.config
+++ b/primarydock.config
@@ -121,7 +121,9 @@ ITERS 50
 
 # Optional output file for docking results. Use a file path with filename,
 # no spaces. If the file exists, it will be overwritten.
-# For best results, include the receptor name (e.g. OR1A1, TAAR5) in the output filename.
+# For best results, include the receptor id (e.g. OR1A1, TAAR5) in the output filename,
+# or use the placeholder %p which will auto-replace with the receptor id.
+# The %l placeholder stands in for the ligand name auto-replacement.
 OUT output/%p_%l.dock
 
 

--- a/primarydock.config
+++ b/primarydock.config
@@ -120,7 +120,7 @@ ITERS 50
 # Optional output file for docking results. Use a file path with filename,
 # no spaces. If the file exists, it will be overwritten.
 # For best results, include the receptor name (e.g. OR1A1, TAAR5) in the output filename.
-OUT output/OR1A1_citral.dock
+OUT output/%p_%l.dock
 
 
 

--- a/primarydock.config
+++ b/primarydock.config
@@ -21,9 +21,11 @@ LIG sdf/citral.sdf
 # Center of binding pocket (required):
 # Can be ABS or RES; default is ABS if unspecified.
 # ABS means use literal XYZ coordinates.
-# RES means average the CA locations of all indicated residue numbers.
+# RES means average the CA locations of all indicated
+#     residue numbers or Ballesteros-Weinstein numbers.
 # CEN ABS -4.93883 5.08067 -4.91533
-CEN RES 105 108 202 206 251 258
+# CEN RES 105 108 202 206 251 258
+CEN RES 3.32 3.33 3.37 3.41 5.39 5.43 5.46 6.48
 
 # Optional path. If given, PrimaryDock will attempt to move the ligand along the
 # path and report the binding energy at each node.

--- a/src/classes/aminoacid.cpp
+++ b/src/classes/aminoacid.cpp
@@ -1600,6 +1600,18 @@ bool AminoAcid::is_tyrosine_like()
     return false;
 }
 
+bool AminoAcid::is_glycine()
+{
+    if (!atoms) return false;
+    int i;
+    for (i=0; atoms[i]; i++)
+    {
+        if (atoms[i]->is_backbone) continue;
+        if (atoms[i]->get_Z() > 1) return false;
+    }
+    return true;
+}
+
 std::ostream& operator<<(std::ostream& os, const AminoAcid& aa)
 {
     if (!&aa) return os;

--- a/src/classes/aminoacid.h
+++ b/src/classes/aminoacid.h
@@ -93,6 +93,7 @@ public:
         return aadef;
     }
     bool is_tyrosine_like();		// An amino acid is tyrosine-like if it has an aromatic ring and a non-backbone H-bond acceptor not part of the ring.
+    bool is_glycine();              // Glycine is a special case where there are no non-backbone heavy atoms.
     float get_reach() const
     {
         return aadef ? aadef->reach : 2.5;

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -250,7 +250,7 @@
 #define _DORESPHRES 0
 #define _DBG_RESBMULT 0
 #define _debug_active_bond_rot 0
-#define _DBG_SPACEDOUT 0
+#define _DBG_SPACEDOUT 1
 #define _DBG_H2O_TELEPORT 0
 #define _DBG_HISFLIP 0
 #define _DBG_MOLBB 0

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -250,7 +250,7 @@
 #define _DORESPHRES 0
 #define _DBG_RESBMULT 0
 #define _debug_active_bond_rot 0
-#define _DBG_SPACEDOUT 1
+#define _DBG_SPACEDOUT 0
 #define _DBG_H2O_TELEPORT 0
 #define _DBG_HISFLIP 0
 #define _DBG_MOLBB 0

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -2087,8 +2087,7 @@ _try_again:
                             if (lig_inter_typ[l] == vdW && reaches_spheroid[nodeno][i]->hydrophilicity() >= 0.3) continue;
                             if (lig_inter_typ[l] == hbond && reaches_spheroid[nodeno][i]->hydrophilicity() < 0.2) continue;
 
-                            // I hate hard coding these, but glycine is the only AA to do this:
-                            if (!strcasecmp(reaches_spheroid[nodeno][i]->get_3letter(), "Gly")) continue;
+                            if (reaches_spheroid[nodeno][i]->is_glycine()) continue;
 
                             #if _DBG_STEPBYSTEP
                             if (debug)

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -321,6 +321,25 @@ void iteration_callback(int iter)
     }
 }
 
+int interpret_resno(char* field)
+{
+    char* dot = strchr(field, '.');
+    if (dot)
+    {
+        *(dot++) = 0;
+        int b = atoi(field);
+        int w = atoi(dot);
+        int _50 = protein->get_bw50(b);
+        if (_50 < 1)
+        {
+            cout << "Error: unknown BW number " << b << "." << w << ", please ensure PDB file has REMARK 800 SITE BW fields." << endl;
+            throw 0xbad12e5;
+        }
+        return _50 + w - 50;
+    }
+    else return atoi(field);
+}
+
 Point pocketcen_from_config_fields(char** fields, Point* old_pocketcen)
 {
     int i=1;
@@ -331,7 +350,7 @@ Point pocketcen_from_config_fields(char** fields, Point* old_pocketcen)
         std::vector<int> resnos;
         for (; fields[i]; i++)
         {
-            int j = atoi(fields[i]);
+            int j = interpret_resno(fields[i]);
             if (!j) break;
             resnos.push_back(j);
         }

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1234,6 +1234,32 @@ int main(int argc, char** argv)
         }
     }
 
+    char* pcntp = strstr(outfname, "%p");
+    if (pcntp)
+    {
+        char tmp[512], protn[64];
+        *(pcntp++) = 0;
+        *(pcntp++) = 0;
+        strcpy(protn, strrchr(protfname, '/')+1);
+        char* dot = strchr(protn, '.');
+        if (dot) *dot = 0;
+        sprintf(tmp, "%s%s%s", outfname, protn, pcntp);
+        strcpy(outfname, tmp);
+    }
+
+    char* pcntl = strstr(outfname, "%l");
+    if (pcntl)
+    {
+        char tmp[512], lign[64];
+        *(pcntl++) = 0;
+        *(pcntl++) = 0;
+        strcpy(lign, strrchr(ligfname, '/')+1);
+        char* dot = strchr(lign, '.');
+        if (dot) *dot = 0;
+        sprintf(tmp, "%s%s%s", outfname, lign, pcntl);
+        strcpy(outfname, tmp);
+    }
+
     #if _DBG_SPACEDOUT
     cout << "Starting a file outstream: " << outfname << endl;
     #endif


### PR DESCRIPTION
Added `bool AminoAcid::is_glycine()` to check if the object is a glycine molecule or residue, obviating the hard coded caseless `name == 'Gly'` kludge that was in the primarydock app.

As this affects the best-binding algorithm, it should be tested on multiple ligands with aliphatic groups.