### PR TITLE
Arginine fix from #202.

### DIFF
--- a/src/classes/aminoacid.cpp
+++ b/src/classes/aminoacid.cpp
@@ -26,10 +26,10 @@ void AminoAcid::find_his_flips()
         if (atoms[i]->get_family() == TETREL)
         {
             Atom* a = atoms[i]->is_bonded_to(PNICTOGEN, 2);
-            if (a)
+            if (a && !a->get_charge())
             {
                 Atom* b = atoms[i]->is_bonded_to(a->get_elem_sym(), 1);
-                if (b)
+                if (b && !b->get_charge())
                 {
                     Atom* h = b->is_bonded_to("H");
                     if (!h) h = a->is_bonded_to("H");

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -985,6 +985,8 @@ bool Atom::is_pi()
         if (bonded_to[0].btom) return bonded_to[0].btom->is_pi();
     }
 
+    if (family == PNICTOGEN && is_bonded_to_pi(TETREL, true) && !is_bonded_to(CHALCOGEN)) return true;
+
     int i;
     for (i=0; i<valence; i++)
     {


### PR DESCRIPTION
- Arginine no longer allows the mistaken hydrogen flip. Only uncharged HN-C=N groups (and congeners) are allowed.
- All pnictogens bound to pi tetrels are themselves pi, unless also bound to a chalcogen.