### PR TITLE
Ligand bias and centralize multimol calculation from #202.

### DIFF
--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -166,6 +166,9 @@
 #define allow_mol_fullrot_iter 0
 #define sidechain_fullrot_lig_bmult 3
 
+// Extra weight given to sidechain-ligand binding strengths during conformer search.
+#define dock_ligand_bias 0.5
+
 // Turns off the 360 degree rotations for all but the zeroth node of a path.
 #define nodes_no_ligand_360_tumble 0
 #define nodes_no_ligand_360_flex 0

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2407,6 +2407,14 @@ float Molecule::get_springy_bond_satisfaction()
     return retval;
 }
 
+float Molecule::intermol_bind_for_multimol_dock(Molecule* om, bool is_ac)
+{
+    float lbias = 1.0 + (sgn(is_residue()) == sgn(om->is_residue()) ? 0 : dock_ligand_bias);
+    float lbind = get_intermol_binding(om, !is_ac) * lbias;
+    // if (!is_residue() && om->is_residue()) lbind += get_intermol_polar_sat(om) * polar_sat_influence_for_dock;
+    return lbind;
+}
+
 #define DBG_BONDFLEX 0
 #define DBG_FLEXRES 111
 #define DBG_FLEXROTB 0
@@ -2515,8 +2523,12 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
 
                 if (nearby[j])
                 {
+                    float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+
                     // get_intermol_binding includes clashes by default, so we don't have to calculate them separately.
-                    float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                    /*float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                    if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                    float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                     bind += lbind;
                     bind -= mm[i]->lastshielded * shielding_avoidance_factor;
                     bind += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2551,7 +2563,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                 {
                     if (!nearby[j]) continue;
                     bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                    float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                    /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                    float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                    if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                    float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                     bind1 += lbind;
                     bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                     bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2582,7 +2597,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                 {
                     if (!nearby[j]) continue;
                     bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                    float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                    /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                    float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                    if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                    float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                     bind1 += lbind;
                     bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                     bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2611,7 +2629,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                 {
                     if (!nearby[j]) continue;
                     bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                    float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                    /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                    float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                    if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                    float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                     bind1 += lbind;
                     bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                     bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2672,7 +2693,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                     {
                         if (!nearby[j]) continue;
                         bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                        /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                        if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                        float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                         bind1 += lbind;
                         if (lbind > maxb) maxb = lbind;
                     }
@@ -2721,7 +2745,11 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                         {
                             if (!nearby[j]) continue;
                             bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
+                            /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
                             float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) + intermol_ESP * mm[i]->get_intermol_potential(all[j]);
+                            if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;
+                            lbind *= lbias;*/
+                            float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                             bind1 += lbind;
                             bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                             bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2758,7 +2786,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                     {
                         if (!nearby[j]) continue;
                         bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                        /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                        if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                        float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                         bind1 += lbind;
                         bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                         bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2804,7 +2835,11 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                         {
                             if (!nearby[j]) continue;
                             bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
+                            /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
                             float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) + intermol_ESP * mm[i]->get_intermol_potential(all[j]);
+                            if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;
+                            lbind *= lbias;*/
+                            float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                             bind1 += lbind;
                             bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                             bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2842,7 +2877,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                     {
                         if (!nearby[j]) continue;
                         bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                        /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                        if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                        float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                         bind1 += lbind;
                         bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                         bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2889,7 +2927,11 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                         {
                             if (!nearby[j]) continue;
                             bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
+                            /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
                             float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) + intermol_ESP * mm[i]->get_intermol_potential(all[j]);
+                            if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;
+                            lbind *= lbias;*/
+                            float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                             bind1 += lbind;
                             bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                             bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2927,7 +2969,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                     {
                         if (!nearby[j]) continue;
                         bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                        /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                        float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                        if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                        float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                         bind1 += lbind;
                         bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                         bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -2994,9 +3039,12 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                         if (!nearby[j]) continue;
                         // cout << ".";
                         bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                        float f = mm[i]->get_intermol_binding(all[j], !is_ac);
-                        if (mm[i]->is_residue() && !all[j]->is_residue()) f *= sidechain_fullrot_lig_bmult;
-                        bind += f;
+                        /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                        float f = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                        if (!mm[i]->is_residue()) f += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                        float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
+                        if (mm[i]->is_residue() && !all[j]->is_residue()) lbind *= sidechain_fullrot_lig_bmult;
+                        bind += lbind;
                         bind -= mm[i]->lastshielded * shielding_avoidance_factor;
                         bind += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
                     }
@@ -3076,6 +3124,7 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                                 {
                                     if (!nearby[j]) continue;
                                     bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
+                                    float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
                                     
                                     float lbind1 =
 
@@ -3083,13 +3132,15 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                                         (mm[i]->mol_typ == MOLTYP_AMINOACID)
                                         ?
                                         #endif
-                                        mm[i]->get_intermol_binding(all[j], !is_ac)
+                                        mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac)
                                         #if allow_ligand_esp
                                         :
                                         mm[i]->get_intermol_potential(all[j]) - 5 * mm[i]->get_internal_clashes()
                                         #endif
                                         ;
-
+                                    
+                                    /*if (!mm[i]->is_residue()) lbind1 += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;
+                                    lbind1 *= lbias;*/
                                     if (mm[i]->is_residue() && !all[j]->is_residue()) lbind1 *= sidechain_fullrot_lig_bmult;
                                     bind1 += lbind1;
                                     bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
@@ -3133,7 +3184,10 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
                             {
                                 if (!nearby[j]) continue;
                                 bool is_ac = false; if (is_ac_i) for (l=0; l<aclen; l++) if (ac[l] == all[j]) { is_ac = true; break; }
-                                float lbind = mm[i]->get_intermol_binding(all[j], !is_ac);
+                                /*float lbias = 1.0 + (sgn(mm[i]->is_residue()) == sgn(all[j]->is_residue()) ? 0 : dock_ligand_bias);
+                                float lbind = mm[i]->get_intermol_binding(all[j], !is_ac) * lbias;
+                                if (!mm[i]->is_residue()) lbind += mm[i]->get_intermol_polar_sat(all[j]) * polar_sat_influence_for_dock;*/
+                                float lbind = mm[i]->intermol_bind_for_multimol_dock(all[j], is_ac);
                                 bind1 += lbind;
                                 bind1 -= mm[i]->lastshielded * shielding_avoidance_factor;
                                 bind1 += mm[i]->get_springy_bond_satisfaction() * bestbind_springiness;
@@ -3196,7 +3250,6 @@ void Molecule::multimol_conform(Molecule** mm, Molecule** bkg, Molecule** ac, in
         if (cb) cb(iter);
     }	// for iter.
 }
-
 
 
 

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -218,6 +218,7 @@ protected:
     void rotate_ring(int ringid, Rotation rot);
     bool in_same_ring(Atom* a, Atom* b);
     float get_atom_error(int atom_idx, LocatedVector* best_lv);
+    float intermol_bind_for_multimol_dock(Molecule* othermol, bool allow_clash);
 
     void intermol_conform_norecen(Molecule* ligand, int iters, Molecule** avoid_clashing_with, float lastbind);
     void intermol_conform_norecen(Molecule** ligands, int iters, Molecule** avoid_clashing_with, float lastbind);

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -61,6 +61,8 @@ struct SoftBias
     float transverse_rotation = 0;              // Rotation about the imaginary line perpendicular to the pocket center.
 };
 
+std::vector<int> extra_wt;
+
 #if _use_gloms
 struct AtomGlom
 {
@@ -276,7 +278,18 @@ struct ResidueGlom
         {
             if (aminos[i]->get_charge() < 0) has_acids = true;
             if (aminos[i]->conditionally_basic()) has_his = true;
-            result += ag->compatibility(aminos[i]);
+
+            float f = ag->compatibility(aminos[i]);
+
+            if (extra_wt.size()
+                    &&
+                    std::find(extra_wt.begin(), extra_wt.end(), aminos[i]->get_residue_no())!=extra_wt.end()
+            )
+            {
+                f *= 1.25;		// Extra weight for residues mentioned in a CEN RES or PATH RES parameter.
+            }
+
+            result += f;
         }
         if (has_acids && has_his && ag->get_ionic() > 0) result -= ag->get_ionic()*30;
 
@@ -310,7 +323,6 @@ std::vector<int> exclusion;
 std::string CEN_buf = "";
 std::vector<std::string> pathstrs;
 std::vector<std::string> states;
-std::vector<int> extra_wt;
 
 bool configset=false, protset=false, ligset=false, pktset=false;
 


### PR DESCRIPTION
- There's a new constant called `dock_ligand_bias` that represents how much proportional additional strength is computed for ligand-protein bindings during multimol dock;
-  The multimol trial-and-error comparison calculation has been moved to a new function called `Molecule::intermol_bind_for_multimol_dock()`.