### PR TITLE
Hydrophobic cohesion.

### DIFF
--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -292,7 +292,7 @@
 #define _dbg_glomsel 0
 #define _dbg_polsat 0
 #define _dbg_softrock 0
-#define _dbg_rock_pic 1
+#define _dbg_rock_pic 0
 
 #endif
 

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -12,6 +12,7 @@
 #define _kcal_per_kJ 0.239006
 #define _kJmol_cuA 0.5
 #define vdw_clash_allowance 1.0
+#define oxytocin 0.007
 #define _DEFAULT_INTERA_R_CUTOFF 8
 #define _INTER_TYPES_LIMIT 10
 #define BOND_DEF_NOT_FOUND 0xbadb09d

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2322,7 +2322,7 @@ float Molecule::get_intermol_binding(Molecule** ligands, bool subtract_clashes)
     return kJmol;
 }
 
-float Molecule::get_intermol_contact_area(Molecule* ligand)
+float Molecule::get_intermol_contact_area(Molecule* ligand, bool hpho)
 {
     if (!ligand) return 0;
     if (!atoms) return 0;
@@ -2333,8 +2333,13 @@ float Molecule::get_intermol_contact_area(Molecule* ligand)
     {
         Point aloc = atoms[i]->get_location();
         float avdw = atoms[i]->get_vdW_radius();
+
+        if (hpho && atoms[i]->is_polar()) continue;
+
         for (j=0; j<ligand->atcount; j++)
         {
+            if (hpho && ligand->atoms[j]->is_polar()) continue;
+
             float r = ligand->atoms[j]->get_location().get_3d_distance(&aloc);
             if (!r) continue;
             float bvdw = ligand->atoms[j]->get_vdW_radius();
@@ -2473,7 +2478,7 @@ float Molecule::intermol_bind_for_multimol_dock(Molecule* om, bool is_ac)
     float lbias = 1.0 + (sgn(is_residue()) == sgn(om->is_residue()) ? 0 : dock_ligand_bias);
     float lbind = get_intermol_binding(om, !is_ac) * lbias;
     // if (!is_residue() && om->is_residue()) lbind += get_intermol_polar_sat(om) * polar_sat_influence_for_dock;
-    lbind += get_intermol_contact_area(om) * oxytocin;
+    lbind += get_intermol_contact_area(om, true) * oxytocin;
     return lbind;
 }
 

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -21,6 +21,7 @@ float conformer_tumble_multiplier = 1;
 
 bool allow_ligand_360_tumble = true;
 bool allow_ligand_360_flex = true;
+bool wet_environment = false;
 
 Molecule::Molecule(char const* lname)
 {
@@ -2478,7 +2479,7 @@ float Molecule::intermol_bind_for_multimol_dock(Molecule* om, bool is_ac)
     float lbias = 1.0 + (sgn(is_residue()) == sgn(om->is_residue()) ? 0 : dock_ligand_bias);
     float lbind = get_intermol_binding(om, !is_ac) * lbias;
     // if (!is_residue() && om->is_residue()) lbind += get_intermol_polar_sat(om) * polar_sat_influence_for_dock;
-    lbind += get_intermol_contact_area(om, true) * oxytocin;
+    if (wet_environment) lbind += get_intermol_contact_area(om, true) * oxytocin;
     return lbind;
 }
 

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -234,6 +234,7 @@ extern float conformer_momenta_multiplier;
 extern float conformer_tumble_multiplier;
 extern bool allow_ligand_360_tumble;
 extern bool allow_ligand_360_flex;
+extern bool wet_environment;
 
 #endif
 

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -148,7 +148,7 @@ public:
     float get_intermol_potential(Molecule** ligands);
     float hydrophilicity();
     float get_intermol_polar_sat(Molecule* ligand);
-    float get_intermol_contact_area(Molecule* ligand);
+    float get_intermol_contact_area(Molecule* ligand, bool hydrophobic_only = false);
 
     float get_vdW_repulsion(Molecule* ligand);
 

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -148,6 +148,7 @@ public:
     float get_intermol_potential(Molecule** ligands);
     float hydrophilicity();
     float get_intermol_polar_sat(Molecule* ligand);
+    float get_intermol_contact_area(Molecule* ligand);
 
     float get_vdW_repulsion(Molecule* ligand);
 

--- a/src/classes/point.cpp
+++ b/src/classes/point.cpp
@@ -495,6 +495,12 @@ float sphere_intersection(float r1, float r2, float d)
            / (12*d);
 }
 
+float sphere_inter_area(float r1, float r2, float d)
+{
+    // https://mathworld.wolfram.com/Sphere-SphereIntersection.html
+    float a = 1.0 / (d*2) * sqrt(4.0 * d*d * r1*r1 - pow(d*d - r2*r2 + r1*r1, 2));
+    return M_PI * a*a;
+}
 
 SCoord v_from_pt_sub(Point distal, Point reference)
 {

--- a/src/classes/point.h
+++ b/src/classes/point.h
@@ -166,7 +166,9 @@ SCoord compute_normal(Point pt1, Point pt2, Point pt3);
 
 float are_points_planar(Point p1, Point p2, Point p3, Point p4);
 float polygon_radius(float side_length, int num_sides);
-float sphere_intersection(float r1, float r2, float d);
+
+float sphere_intersection(float r1, float r2, float d);         // Volume of the lens composed of the two caps.
+float sphere_inter_area(float r1, float r2, float d);           // Area of the circle formed by the spheres' intersection.
 
 SCoord v_from_pt_sub(Point distal, Point reference);
 

--- a/src/molecule_test.cpp
+++ b/src/molecule_test.cpp
@@ -17,6 +17,8 @@ int main(int argc, char** argv)
     float clash_limit = 8;
     float N_O_spacing = 4 * 2;
 
+    wet_environment = true;
+
     Molecule m("nothing");
     cout << "Created empty molecule named " << m.get_name() << ".\n";
 

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1439,6 +1439,10 @@ int interpret_config_line(char** words)
         }
         return i-1;
     }
+    else if (!strcmp(words[0], "WET"))
+    {
+        wet_environment = true;
+    }
 
     return 0;
 }

--- a/test/test1A1.config
+++ b/test/test1A1.config
@@ -20,6 +20,7 @@ CEN RES 2.53 3.29 3.32 3.33 3.36 3.37 3.40 3.41 4.53 4.57 4.60 45.49 45.52 5.39 
 
 # Pocket size.
 SIZE 6.0 7.5 5.5
+WET
 
 # Exclusion from pocket.
 EXCL 1 57		# Head, TMR1, and CYT1.


### PR DESCRIPTION
A.k.a. oil cuddling. Hydrophobic atoms will now exhibit a strong tendency to stick together, since their surroundings will be assumed to be predominantly hydrophilic as they are in olfactory receptor EXR and CYT regions, and in the spaces between the TM helices.

A new constant named `oxytocin` mediates the effect, in order to balance the amino aldehyde test, which prefers low values of the new constant, and the following dialkane test, which prefers high values:

`clear; make test/molecule_test && ./test/molecule_test 'CCCCCC' 'CCCCCC'`

A successful dialkane result shows the two chains lined up side by side, e.g.:

![image](https://user-images.githubusercontent.com/66374250/224612901-9be9a200-a9e7-4e02-aa30-14e63ce7b92d.png)
