### PR TITLE
Recalculate can-clash residues when move part of a protein.

### DIFF
--- a/src/classes/protein.h
+++ b/src/classes/protein.h
@@ -32,7 +32,7 @@ public:
     bool add_residue(const int resno, const char aaletter);
     bool add_sequence(const char* sequence);
     bool add_residue(const char* pdbdata);
-    void set_clashables();
+    void set_clashables(int resno = 0);
     void delete_residue(int resno);
     void delete_sidechain(int resno);
     void delete_residues(int startres, int endres);


### PR DESCRIPTION
`Protein::set_clashables()` now accepts an optional int resno. When `iteration_callback()` calls `protein->get_internal_clashes()` with a start and end resno, it will recompute the nearby clashable residues for the segment of protein in motion.

This does, however, prevent the soft rock activation of 51E2 by propionate.

TODO: `Protein::set_clashables()` should also recompute the clashables for each newly identified nearby residue. If done as a recursion, it should be limited to one layer deep.