### PR TITLE
--movie mode now allows multiple poses, nodes.

### DIFF
--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1013,7 +1013,7 @@ void iteration_callback(int iter)
     {
         std::string itersfname = (std::string)"tmp/" + (std::string)protein->get_name() + (std::string)"_iters.dock";
         int liter = iter + movie_offset;
-        FILE* fp = fopen(itersfname.c_str(), ((liter == 1 && pose == 1) ? "wb" : "ab") );
+        FILE* fp = fopen(itersfname.c_str(), ((liter == 0 && pose == 1) ? "wb" : "ab") );
         if (fp)
         {
             fprintf(fp, "Pose: %d\nNode: %d\n\nPDBDAT:\n", pose, liter);

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1013,7 +1013,7 @@ void iteration_callback(int iter)
     {
         std::string itersfname = (std::string)"tmp/" + (std::string)protein->get_name() + (std::string)"_iters.dock";
         int liter = iter + movie_offset;
-        FILE* fp = fopen(itersfname.c_str(), (liter == 1 ? "wb" : "ab") );
+        FILE* fp = fopen(itersfname.c_str(), ((liter == 1 && pose == 1) ? "wb" : "ab") );
         if (fp)
         {
             fprintf(fp, "Pose: %d\nNode: %d\n\nPDBDAT:\n", pose, liter);
@@ -2781,7 +2781,7 @@ _try_again:
 
         for (nodeno=0; nodeno<=pathnodes; nodeno++)
         {
-            movie_offset = iters * (nodeno + (pose-1)*(pathnodes+1));
+            movie_offset = iters * (nodeno /*+ (pose-1)*(pathnodes+1)*/);
 
             if (waters)
             {

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1016,7 +1016,7 @@ void iteration_callback(int iter)
         FILE* fp = fopen(itersfname.c_str(), (liter == 1 ? "wb" : "ab") );
         if (fp)
         {
-            fprintf(fp, "Pose: 1\nNode: %d\n\nPDBDAT:\n", liter);
+            fprintf(fp, "Pose: %d\nNode: %d\n\nPDBDAT:\n", pose, liter);
             /*protein->save_pdb(fp, ligand);
             protein->end_pdb(fp);*/
 
@@ -2781,7 +2781,7 @@ _try_again:
 
         for (nodeno=0; nodeno<=pathnodes; nodeno++)
         {
-            movie_offset = iters * (nodeno + (pose-1)*pathnodes);
+            movie_offset = iters * (nodeno + (pose-1)*(pathnodes+1));
 
             if (waters)
             {

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -328,6 +328,7 @@ char* get_file_ext(char* filename)
 }
 
 bool output_each_iter = false;
+int movie_offset = 0;
 char configfname[256];
 char protfname[256];
 char protafname[256];
@@ -1011,10 +1012,11 @@ void iteration_callback(int iter)
     if (output_each_iter)
     {
         std::string itersfname = (std::string)"tmp/" + (std::string)protein->get_name() + (std::string)"_iters.dock";
-        FILE* fp = fopen(itersfname.c_str(), (iter == 1 ? "wb" : "ab") );
+        int liter = iter + movie_offset;
+        FILE* fp = fopen(itersfname.c_str(), (liter == 1 ? "wb" : "ab") );
         if (fp)
         {
-            fprintf(fp, "Pose: 1\nNode: %d\n\nPDBDAT:\n", iter);
+            fprintf(fp, "Pose: 1\nNode: %d\n\nPDBDAT:\n", liter);
             /*protein->save_pdb(fp, ligand);
             protein->end_pdb(fp);*/
 
@@ -1023,7 +1025,7 @@ void iteration_callback(int iter)
             sphres = protein->get_residues_can_clash_ligand(reaches_spheroid, ligand, pocketcen, size, addl_resno);*/
             int foff = 0;
 
-            for (i=0; i<sphres; i++)
+            for (i=0; reaches_spheroid[nodeno][i]; i++)
             {
                 reaches_spheroid[nodeno][i]->save_pdb(fp, foff);
                 foff += reaches_spheroid[nodeno][i]->get_atom_count();
@@ -2779,6 +2781,7 @@ _try_again:
 
         for (nodeno=0; nodeno<=pathnodes; nodeno++)
         {
+            movie_offset = iters * (nodeno + (pose-1)*pathnodes);
 
             if (waters)
             {
@@ -4447,8 +4450,6 @@ _try_again:
                 break;
             }
         }	// nodeno loop.
-
-        if (output_each_iter) break;
     } // pose loop.
     #if _DBG_STEPBYSTEP
     if (debug) *debug << "Finished poses." << endl;


### PR DESCRIPTION
The --movie option, useful for tracking docking progress by outputting each iteration as a discrete node to a temporary dock file, no longer stops cold after the zeroth node of the first pose. Now it will output every pose and, within each pose, all iterations of all path nodes sequentially. So for instance if your dock has 50 iterations and 3 path nodes, then it will output the iterations for path node 0 as movie noes 0 - 49, path node 1 as 50 - 99, etc.

Note that the pose numbers of the temp file are the sequence the poses were computed in, not the same as the pose numbers of the normal output, which are sorted by total energy.