### PR TITLE
Another segfault fix.

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -28,7 +28,7 @@ Casting an integer to a Cartesian obtains the location of the CA atom for that r
 
 Casting a Cartesian back to float or integer obtains the magnitude of the Cartesian, equal to sqrt(x^2 + y^2 + z^2).
 
-The command line arguments are made available to the script as $arg1, $arg2, etc.
+The command line arguments are made available to the script as $arg1, $arg2, etc. Normally, $arg1 will be the .pepd script filename.
 
 
 Array functionality is available, though not implemented as true arrays. Each element is internally stored as its own discrete variable, for example
@@ -301,6 +301,15 @@ to write a series of `ELSE IF`s, or to combine `IF`s, e.g. `IF &var1 > 0 IF &var
 in exactly this way by transparently replacing `AND` with `IF` behind the scenes.
 
 When using `IF` with `GOTO`, it is possible to create loops as seen in the last example above.
+
+
+# HYDRO
+Examples:
+```
+HYDRO
+```
+
+Hydrogenates the protein.
 
 
 # LET

--- a/makefile
+++ b/makefile
@@ -119,7 +119,7 @@ point_report: test/point_test
 
 molecule_report: REPORT="test/molecule_test1.approved.txt"
 molecule_report: test/molecule_test
-	./test/molecule_test 'NCCCC=O' 'NCCCC=O' | tee temp | sed '/^#/d' >test/molecule_test1.received.txt; cat temp # ignore lines starting with #
+	./test/molecule_test 'c1ccccc1' 'c1ccccc1' | tee temp | sed '/^#/d' >test/molecule_test1.received.txt; cat temp # ignore lines starting with #
 	diff --color --unified $(REPORT) test/molecule_test1.received.txt
 
 mol_assem_report: REPORT="test/mol_assem_test.approved.txt"

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -470,8 +470,9 @@ void Molecule::hydrogenate(bool steric_only)
                 }
             }
         }
-
     }
+
+    for (atcount=0; atoms[atcount]; atcount++);     // Update count.
 
     clear_all_bond_caches();
 }
@@ -2117,6 +2118,7 @@ bool Molecule::shielded(Atom* a, Atom* b) const
     for (i=0; i<atcount; i++)
     {
         Atom* ai = atoms[i];
+        if (!ai) break;
         if (ai == a || ai == b) continue;
         float rai = ai->distance_to(a);
         if (rai > r6) continue;
@@ -2209,12 +2211,14 @@ float Molecule::get_intermol_potential(Molecule** ligands, bool pure)
 
     for (i=0; i<atcount; i++)
     {
+        if (!atoms[i]) continue;
         Point aloc = atoms[i]->get_location();
         for (l=0; ligands[l]; l++)
         {
             if (ligands[l] == this) continue;
             for (j=0; j<ligands[l]->atcount; j++)
             {
+                if (!ligands[l]->atoms[j]) continue;
                 float r = ligands[l]->atoms[j]->get_location().get_3d_distance(&aloc);
                 float f = 1.0 / r;		// Regular invert rather than inv square so that actual bonding will take over at short range.
                 InteratomicForce** iff = InteratomicForce::get_applicable(atoms[i], ligands[l]->atoms[j]);

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -281,12 +281,13 @@ Atom* Molecule::add_atom(char const* elemsym, char const* aname, Atom* bondto, c
         atoms[atcount] = nullptr;
         a->bond_to(bondto, bcard);
 
+        clear_all_bond_caches();
+
         if ((atcount & 1) && bondto->get_bonded_atoms_count() == 2)
         {
             Bond* b = bondto->get_bond_between(a);
             if (b && b->can_rotate)
             {
-                b->clear_moves_with_cache();
                 b->rotate(M_PI);
             }
         }

--- a/src/molecule_test.cpp
+++ b/src/molecule_test.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
         }
 
         Point rc = m1.get_ring_center(i);
-        cout << "Ring centered at [" << rc.x << "," << rc.y << "," << rc.z << "]." << endl;
+        cout << "# Ring centered at [" << rc.x << "," << rc.y << "," << rc.z << "]." << endl;
 
         if (cp)
         {

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -5069,6 +5069,15 @@ _exitposes:
     {
         if (output)
         {
+            hydrogenate_pdb = false;
+            pf = fopen(protfname, "r");
+            if (!pf)
+            {
+                cout << "Error trying to read " << protfname << endl;
+                return 0xbadf12e;
+            }
+            protein->load_pdb(pf);
+            fclose(pf);
             FILE* pf = fopen(outfname, "ab");
             fprintf(pf, "\nOriginal PDB:\n");
             protein->save_pdb(pf);

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -2816,7 +2816,7 @@ _try_again:
         }
         else
         {
-            pf = fopen(protafname, "r");
+            pf = fopen(protfname, "r");
             protein->load_pdb(pf);
             fclose(pf);
         }
@@ -2923,7 +2923,7 @@ _try_again:
                 #if prevent_ligand_360_on_activate
                 allow_ligand_360_tumble = allow_ligand_360_flex = false;
                 #endif
-                
+
                 // Persist the flexions of the side chains. 
                 // TODO: Do not persist those residues whose positions are important to activation.
                 float* sidechain_bondrots[seql+4];
@@ -2950,6 +2950,15 @@ _try_again:
                         delete[] b;
                     }
                 }
+
+                delete protein;
+                protein = new Protein(protafname);
+                
+                pf = fopen(protafname, "r");
+                protein->load_pdb(pf);
+                fclose(pf);
+
+                prepare_initb();
 
                 for (i=1; i<=seql; i++)
                 {

--- a/test/molecule_test1.approved.txt
+++ b/test/molecule_test1.approved.txt
@@ -1,13 +1,9 @@
 Created empty molecule named nothing.
-Created molecule named NCCCC=O.
-Loaded 0 atoms of NCCCC=O into molecule.
-Atom N1 has basicity 1
-Atom H7 has basicity 1
-Atom H8 has basicity 1
-Bond N1 - C2 can rotate.
-Bond C2 - C3 can rotate.
-Bond C3 - C4 can rotate.
-Bond C4 - C5 can rotate.
+Created molecule named c1ccccc1.
+Loaded 0 atoms of c1ccccc1 into molecule.
+Found 1 ring(s).
+Ring atoms: C5 C6 C1 C2 C3 C4 
+
 
 Energy level below threshold, SUCCESS.
 Saved output.sdf


### PR DESCRIPTION
After calling hydrogenate() on a protein, some of the Molecule objects have an atcount that exceeds non-null Atom objects. This PR attempts a fix and implements a workaround.

No change to docking classes.