### PR TITLE
Progress bar

### DIFF
--- a/primarydock.config
+++ b/primarydock.config
@@ -195,6 +195,9 @@ ITERS 50
 # The %l placeholder stands in for the ligand name auto-replacement.
 OUT output/%p_%l.dock
 
+# Optional: Show a progress bar on the screen.
+# PROGRESS
+
 # Optional: If docking in a custom PDB that is not one of the included olfactory PDBs,
 # the docked PDB can be appended to the .dock file so that the viewer can display the
 # entire result including the protein backbone:

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1073,7 +1073,7 @@ void iteration_callback(int iter)
         for (i=0; i<80; i++)
         {
             float cmpi = 1.25*i;
-            if (cmpi <= percentage) cout << "\u2593";
+            if (cmpi <= percentage) cout << "\u2592";
             else cout << "-";
         }
         i = iter % 4;
@@ -4749,6 +4749,11 @@ _try_again:
     #if _DBG_STEPBYSTEP
     if (debug) *debug << "Finished poses." << endl;
     #endif
+
+    if (progressbar)
+    {
+        cout << "\033[A\033[K";
+    }
 
     // Output the dr[][] array in order of increasing pose number.
     cout << endl;

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1073,7 +1073,7 @@ void iteration_callback(int iter)
         for (i=0; i<80; i++)
         {
             float cmpi = 1.25*i;
-            if (cmpi <= percentage) cout << "\u2588";
+            if (cmpi <= percentage) cout << "\u2593";
             else cout << "-";
         }
         i = iter % 4;
@@ -1503,7 +1503,6 @@ int interpret_config_line(char** words)
     else if (!strcmp(words[0], "PROGRESS"))
     {
         progressbar = true;
-        // optsecho = "Protein file is " + (std::string)protfname;
         return 0;
     }
     else if (!strcmp(words[0], "PROT"))

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1062,6 +1062,19 @@ void iteration_callback(int iter)
             fclose(fp);
         }
     }
+
+    int ni = (pathnodes+1) * iters, pni = poses * ni;
+    float percentage = (float)((pose-1) * ni + nodeno * iters + iter) / pni * 100;
+
+    cout << "\033[A|";
+    for (i=0; i<80; i++)
+    {
+        float cmpi = 1.25*i;
+        if (cmpi <= percentage) cout << "\u2588";
+        else cout << "-";
+    }
+    i = iter % 4;
+    cout << ("|/-\\")[i] << " " << (int)percentage << "%.               " << endl;
 }
 
 int interpret_resno(const char* field)

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -351,6 +351,7 @@ char* get_file_ext(char* filename)
 }
 
 bool output_each_iter = false;
+bool progressbar = false;
 int movie_offset = 0;
 char configfname[256];
 char protfname[256];
@@ -1063,18 +1064,21 @@ void iteration_callback(int iter)
         }
     }
 
-    int ni = (pathnodes+1) * iters, pni = poses * ni;
-    float percentage = (float)((pose-1) * ni + nodeno * iters + iter) / pni * 100;
-
-    cout << "\033[A|";
-    for (i=0; i<80; i++)
+    if (progressbar)
     {
-        float cmpi = 1.25*i;
-        if (cmpi <= percentage) cout << "\u2588";
-        else cout << "-";
+        int ni = (pathnodes+1) * iters, pni = poses * ni;
+        float percentage = (float)((pose-1) * ni + nodeno * iters + iter) / pni * 100;
+
+        cout << "\033[A|";
+        for (i=0; i<80; i++)
+        {
+            float cmpi = 1.25*i;
+            if (cmpi <= percentage) cout << "\u2588";
+            else cout << "-";
+        }
+        i = iter % 4;
+        cout << ("|/-\\")[i] << " " << (int)percentage << "%.               " << endl;
     }
-    i = iter % 4;
-    cout << ("|/-\\")[i] << " " << (int)percentage << "%.               " << endl;
 }
 
 int interpret_resno(const char* field)
@@ -1495,6 +1499,12 @@ int interpret_config_line(char** words)
         use_prealign = true;
         prealign_residues = origbuff;
         return 1;
+    }
+    else if (!strcmp(words[0], "PROGRESS"))
+    {
+        progressbar = true;
+        // optsecho = "Protein file is " + (std::string)protfname;
+        return 0;
     }
     else if (!strcmp(words[0], "PROT"))
     {


### PR DESCRIPTION
Users can now specify `PROGRESS` in the .config file, or `--progress` in the command line, to see a progress bar on screen that indicates how far along the dock has come.

No change to the classes.