### PR TITLE
Limit heavy atoms to sum of van der Waals radii.

### DIFF
--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -10,7 +10,7 @@
 #define hexagonal (M_PI/3)
 
 #define _kcal_per_kJ 0.239006
-#define _kJmol_cuA 0.5
+#define _kJmol_cuA 1.0
 // #define coplanar_threshold 0.5
 #define coplanar_threshold 2.5
 #define oxytocin 0.003

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -10,7 +10,7 @@
 #define hexagonal (M_PI/3)
 
 #define _kcal_per_kJ 0.239006
-#define _kJmol_cuA 1.0
+#define _kJmol_cuA 0.5
 // #define coplanar_threshold 0.5
 #define coplanar_threshold 2.5
 #define oxytocin 0.003

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -718,11 +718,6 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
         if (!forces[i]->distance) continue;
         float r1 = r / forces[i]->distance;
 
-        if (sgn(achg) == sgn(bchg))
-        {
-            r1 += 0.001;
-        }
-
         if (forces[i]->type == covalent) continue;
         
         float partial, rdecayed;
@@ -1053,16 +1048,6 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
             if (forces[i]->type == ionic && a->get_charge() && b->get_charge())
             {
                 partial *= a->get_charge() * -(b->get_charge());
-
-                if (0 && (a->residue == 114 || b->residue == 114))
-                    cout << "Ionic interaction between "
-                        << a->name << " (" << a->get_charge() << ") and "
-                        << b->name << " ("  << b->get_charge() << ")"
-                        << " r=" << r
-                        << " (optimal " << forces[i]->distance << ") rdecayed=" << rdecayed
-                        << " aniso=" << aniso << " (" << asum << "*" << bsum << ") = "
-                        << partial
-                        << endl;
             }
 
             if (forces[i]->type == hbond) partial *= fabs(apol) * fabs(bpol);

--- a/test/testTAAR9.PEA.config
+++ b/test/testTAAR9.PEA.config
@@ -1,0 +1,41 @@
+
+# PrimaryDock test configuration file.
+#
+
+# Path to PDB of protein (required):
+PROT pdbs/TAAR/TAAR9.upright.pdb
+
+# Path to PDB or SDF of ligand (required):
+LIG sdf/phenethylamine.sdf
+SMILES c1ccccc1CC[NH3+]
+
+CEN RES 3.32 3.37 5.42 6.48 6.51
+
+# Pocket size.
+SIZE 8 8 8
+
+# Maximum number of poses to output. Default 10.
+POSE 10
+
+# Minimum total binding energy in kJ/mol for output poses.
+# ELIM -0.01
+# ELIM 10000
+
+# Side chain flexion: active if nonzero. Default: 1.
+FLEX 1
+FLXR 6.48
+BRIDGE 3.32 7.43
+STCR 3.32 7.43
+
+# Number of iterations per path node per pose.
+ITERS 50
+
+PROGRESS
+
+# Optional output file for docking results.
+OUT output/test_%p_%l.dock
+
+# Colorize output energies.
+COLORS
+
+


### PR DESCRIPTION
Ensures heavy atoms will not be brought closer together than their combined vdW radii, unless they or their hydrogens share an interaction.

Also fixes a problem where like charges were registering as attractive instead of repulsive.