### PR TITLE
Urgent fix for TAAR test.

### DIFF
--- a/src/classes/group.cpp
+++ b/src/classes/group.cpp
@@ -981,6 +981,16 @@ std::vector<std::shared_ptr<GroupPair>> GroupPair::pair_groups(std::vector<std::
 
 void GroupPair::align_groups(Molecule* lig, std::vector<std::shared_ptr<GroupPair>> gp)
 {
+    GroupPair::align_groups(lig, gp, true);
+}
+
+void GroupPair::align_groups_noconfig(Molecule* lig, std::vector<std::shared_ptr<GroupPair>> gp)
+{
+    GroupPair::align_groups(lig, gp, false);
+}
+
+void GroupPair::align_groups(Molecule* lig, std::vector<std::shared_ptr<GroupPair>> gp, bool do_conforms)
+{
     int n = gp.size();
 
     if (n < 1) return;
@@ -1004,7 +1014,7 @@ void GroupPair::align_groups(Molecule* lig, std::vector<std::shared_ptr<GroupPai
         lig->move(rel);
     }
 
-    gp[0]->scg->conform_to(lig);
+    if (do_conforms) gp[0]->scg->conform_to(lig);
 
     if (n < 2) return;
     rot = align_points_3d(gp[1]->ag->get_center(), gp[1]->scg->get_center(), gp[0]->ag->get_center());
@@ -1015,7 +1025,7 @@ void GroupPair::align_groups(Molecule* lig, std::vector<std::shared_ptr<GroupPai
     #endif
     lig->rotate(lv, rot.a);
 
-    gp[1]->scg->conform_to(lig);
+    if (do_conforms) gp[1]->scg->conform_to(lig);
 
     if (n < 3) return;
     Point zcen = gp[0]->ag->get_center();
@@ -1028,6 +1038,6 @@ void GroupPair::align_groups(Molecule* lig, std::vector<std::shared_ptr<GroupPai
     #endif
     lig->rotate(lv, theta);
 
-    gp[2]->scg->conform_to(lig);
+    if (do_conforms) gp[2]->scg->conform_to(lig);
 }
 

--- a/src/classes/group.cpp
+++ b/src/classes/group.cpp
@@ -984,7 +984,7 @@ void GroupPair::align_groups(Molecule* lig, std::vector<std::shared_ptr<GroupPai
     GroupPair::align_groups(lig, gp, true);
 }
 
-void GroupPair::align_groups_noconfig(Molecule* lig, std::vector<std::shared_ptr<GroupPair>> gp)
+void GroupPair::align_groups_noconform(Molecule* lig, std::vector<std::shared_ptr<GroupPair>> gp)
 {
     GroupPair::align_groups(lig, gp, false);
 }

--- a/src/classes/group.h
+++ b/src/classes/group.h
@@ -80,7 +80,7 @@ class GroupPair
 
     static std::vector<std::shared_ptr<GroupPair>> pair_groups(std::vector<std::shared_ptr<AtomGroup>> agroups, std::vector<std::shared_ptr<ResidueGroup>> scgroups, Point pocketcen);
     static void align_groups(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs);
-    static void align_groups_noconfig(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs);
+    static void align_groups_noconform(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs);
     static void align_groups(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs, bool do_conforms);    // Assumes the ligand is already centered in the pocket.
 
     protected:

--- a/src/classes/group.h
+++ b/src/classes/group.h
@@ -79,7 +79,9 @@ class GroupPair
     bool is_priority() { return priority; }
 
     static std::vector<std::shared_ptr<GroupPair>> pair_groups(std::vector<std::shared_ptr<AtomGroup>> agroups, std::vector<std::shared_ptr<ResidueGroup>> scgroups, Point pocketcen);
-    static void align_groups(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs);    // Assumes the ligand is already centered in the pocket.
+    static void align_groups(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs);
+    static void align_groups_noconfig(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs);
+    static void align_groups(Molecule* ligand, std::vector<std::shared_ptr<GroupPair>> group_pairs, bool do_conforms);    // Assumes the ligand is already centered in the pocket.
 
     protected:
     float potential = 0;

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -3001,6 +3001,12 @@ void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molec
                         else theta = frand(-0.3, 0.3)*fiftyseventh*min(iter, 20);
 
                         bb[q]->rotate(theta, false);
+
+                        if (a->agroups.size() && a->group_realign)
+                        {
+                            a->group_realign(a, a->agroups);
+                        }
+
                         tryenerg = cfmol_multibind(a, nearby);
 
                         if (tryenerg > benerg)

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2694,7 +2694,7 @@ float Molecule::cfmol_multibind(Molecule* a, Molecule** nearby)
     return tryenerg;
 }
 
-void Molecule::conform_molecules(Molecule** mm, Molecule** bkg, int iters, void (*cb)(int, Molecule**))
+void Molecule::conform_molecules(Molecule** mm, Molecule** bkg, int iters, void (*cb)(int, Molecule**), void (*group_realign)(Molecule*, std::vector<std::shared_ptr<GroupPair>>))
 {
     int m, n;
 
@@ -2735,7 +2735,7 @@ void Molecule::conform_molecules(Molecule** mm, Molecule** bkg, int iters, void 
 
     all[l] = nullptr;
 
-    conform_molecules(all, iters, cb);
+    conform_molecules(all, iters, cb, group_realign);
 
     for (i=0; i<n; i++)
     {
@@ -2811,7 +2811,7 @@ float Molecule::total_intermol_binding(Molecule** l)
     return f;
 }
 
-void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molecule**))
+void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molecule**), void (*group_realign)(Molecule*, std::vector<std::shared_ptr<GroupPair>>))
 {
     if (!mm) return;
     int i, j, l, n, iter;
@@ -3002,9 +3002,9 @@ void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molec
 
                         bb[q]->rotate(theta, false);
 
-                        if (a->agroups.size() && a->group_realign)
+                        if (a->agroups.size() && group_realign)
                         {
-                            a->group_realign(a, a->agroups);
+                            group_realign(a, a->agroups);
                         }
 
                         tryenerg = cfmol_multibind(a, nearby);

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -176,9 +176,9 @@ public:
     float bindability_by_type(intera_type type, bool include_backbone = false);
 
     static float total_intermol_binding(Molecule** ligands);
-    static void conform_molecules(Molecule** molecules, int iterations = 50, void (*callback)(int, Molecule**) = nullptr);
-    static void conform_molecules(Molecule** molecules, Molecule** background, int iterations = 50, void (*callback)(int, Molecule**) = nullptr);
-    static void conform_molecules(Molecule** molecules, Molecule** background, Molecule** clashables, int iterations = 50, void (*callback)(int, Molecule**) = nullptr);
+    static void conform_molecules(Molecule** molecules, int iterations = 50, void (*callback)(int, Molecule**) = nullptr, void (*group_realign)(Molecule*, std::vector<std::shared_ptr<GroupPair>>) = nullptr);
+    static void conform_molecules(Molecule** molecules, Molecule** background, int iterations = 50, void (*callback)(int, Molecule**) = nullptr, void (*group_realign)(Molecule*, std::vector<std::shared_ptr<GroupPair>>) = nullptr);
+    static void conform_molecules(Molecule** molecules, Molecule** background, Molecule** clashables, int iterations = 50, void (*callback)(int, Molecule**) = nullptr, void (*group_realign)(Molecule*, std::vector<std::shared_ptr<GroupPair>>) = nullptr);
     void conform_atom_to_location(int atom_idx, Point target, int iterations = 50);
     void conform_atom_to_location(char* atom_name, Point target, int iterations = 50);
     SCoord motion_to_optimal_contact(Molecule* ligand);
@@ -221,7 +221,6 @@ public:
     bool been_flexed = false;
     bool priority = false;
     std::vector<std::shared_ptr<GroupPair>> agroups;
-    void (*group_realign)(Molecule*, std::vector<std::shared_ptr<GroupPair>>) = nullptr;
 
 protected:
     Molecule();

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -49,6 +49,8 @@ enum MoleculeType
     MOLTYP_AMINOACID
 };
 
+class GroupPair;
+
 class Pose
 {
 public:

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -5,6 +5,7 @@
 #define _MOLECULE
 
 #include <vector>
+#include <memory>
 
 struct SMILES_Parenthetical
 {
@@ -50,6 +51,7 @@ enum MoleculeType
 };
 
 class GroupPair;
+class AtomGroup;
 
 class Pose
 {
@@ -218,6 +220,8 @@ public:
     int springy_bondct = 0;
     bool been_flexed = false;
     bool priority = false;
+    std::vector<std::shared_ptr<GroupPair>> agroups;
+    void (*group_realign)(Molecule*, std::vector<std::shared_ptr<GroupPair>>) = nullptr;
 
 protected:
     Molecule();

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -3906,7 +3906,7 @@ _try_again:
 
             ligand->movability = (MovabilityType)(MOV_ALL - MOV_MC_AXIAL);
             ligand->agroups = global_pairs;
-            Molecule::conform_molecules(cfmols, iters, &iteration_callback, &GroupPair::align_groups_noconfig);
+            Molecule::conform_molecules(cfmols, iters, &iteration_callback, &GroupPair::align_groups_noconform);
 
             if (!nodeno && outpdb.length())
             {

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -3905,6 +3905,8 @@ _try_again:
             freeze_bridged_residues();
 
             ligand->movability = (MovabilityType)(MOV_ALL - MOV_MC_AXIAL);
+            ligand->agroups = global_pairs;
+            ligand->group_realign = &GroupPair::align_groups;
             Molecule::conform_molecules(cfmols, iters, &iteration_callback);
 
             if (!nodeno && outpdb.length())

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -3906,8 +3906,7 @@ _try_again:
 
             ligand->movability = (MovabilityType)(MOV_ALL - MOV_MC_AXIAL);
             ligand->agroups = global_pairs;
-            ligand->group_realign = &GroupPair::align_groups;
-            Molecule::conform_molecules(cfmols, iters, &iteration_callback);
+            Molecule::conform_molecules(cfmols, iters, &iteration_callback, &GroupPair::align_groups_noconfig);
 
             if (!nodeno && outpdb.length())
             {

--- a/test/testTAAR8.config
+++ b/test/testTAAR8.config
@@ -9,7 +9,7 @@ PROT pdbs/TAAR/TAAR8.upright.pdb
 LIG sdf/cadaverine.sdf
 SMILES [NH3+]CCCCC[NH3+]
 
-CEN RES 3.32 3.37 5.42 6.48 7.43
+CEN RES 3.32 3.37 5.43 6.48 7.43
 
 # Pocket size.
 SIZE 7 7 7
@@ -23,7 +23,9 @@ POSE 5
 
 # Side chain flexion: active if nonzero. Default: 1.
 FLEX 1
-FLXR 3.32 5.43 6.48
+FLXR 3.32 5.43
+ATOMTO 6.48 EXTENT 3.36
+STCR 6.48
 
 # Number of iterations per path node per pose.
 ITERS 50

--- a/test/testTAAR8.config
+++ b/test/testTAAR8.config
@@ -11,14 +11,6 @@ SMILES [NH3+]CCCCC[NH3+]
 
 CEN RES 3.32 3.37 5.42 6.48 7.43
 
-# PATH RES 1 112 206 251
-# PATH RES 2 115 213 244
-# PATH RES 3 59 118 240
-# PATH RES 4 126 224 233
-
-# Optional protein conformational states.
-# STATE 3 210 248 25
-
 # Pocket size.
 SIZE 7 7 7
 


### PR DESCRIPTION
Ligand flexion attempts in conform_molecules() are now accompanied by a realignment of the best-binding atom groups with their residue groups. The TAAR8 cadaverine dock now makes contacts of ca. -30 kJ/mol with D111 and D201.