### PR TITLE
Additional improvements for TAAR8 cadaverine test.

### DIFF
--- a/src/classes/group.h
+++ b/src/classes/group.h
@@ -36,6 +36,8 @@ class AtomGroup
     float get_sum();
     float get_avg_elecn();
     int contains_element(const char* esym);
+    bool contains_atom(Atom* a);
+    void remove_atom(Atom* a);
     float distance_to(Point pt);
     float bounds();
     float compatibility(AminoAcid* aa);

--- a/test/testTAAR8.config
+++ b/test/testTAAR8.config
@@ -35,7 +35,7 @@ PROGRESS
 
 # Optional output file for docking results.
 OUT output/test_%p_%l.dock
-OUTPDB 2 output/test_%p_%l.model%o.pdb
+# OUTPDB 2 output/test_%p_%l.model%o.pdb
 
 # Colorize output energies for at-a-glance verification.
 COLORS

--- a/test/testTAAR8.config
+++ b/test/testTAAR8.config
@@ -23,9 +23,10 @@ POSE 5
 
 # Side chain flexion: active if nonzero. Default: 1.
 FLEX 1
-FLXR 3.32 5.43
-ATOMTO 6.48 EXTENT 3.36
-STCR 6.48
+FLXR 5.43
+ATOMTO 6.48 HZ3 3.36
+BRIDGE 7.43 3.32
+STCR 3.32 6.48
 
 # Number of iterations per path node per pose.
 ITERS 50
@@ -34,6 +35,7 @@ PROGRESS
 
 # Optional output file for docking results.
 OUT output/test_%p_%l.dock
+OUTPDB 2 output/test_%p_%l.model%o.pdb
 
 # Colorize output energies for at-a-glance verification.
 COLORS


### PR DESCRIPTION
The AtomGroup::get_potential_ligand_groups() function now imposes a limit on its output that no two groups may share the same atom. For the TAAR test, this results in the two amino moieties each getting their own AtomGroup, with the aliphatic chain residing in a separate AtomGroup. The result of the improved group assignments is that the best binding algorithm has a strong tendency to assign the aliphatic chain to Cys115, placing it in the right position to force W6.48's side chain into a lowered position near F5.47, likely engaging the receptor activation mechanism.