### PR TITLE
Distinguish orphan vs. deorphaned receptors in conserved.php utility.

### DIFF
--- a/data/conserved.php
+++ b/data/conserved.php
@@ -4,6 +4,7 @@ chdir(__DIR__);
 chdir("..");
 
 require("predict/statistics.php");
+require("data/odorutils.php");
 
 $colors =
 [
@@ -17,6 +18,10 @@ $colors =
     "H" => "\033[38;5;99m",
     "FWY" => "\033[38;5;171m"
 ];
+
+$orphan = "\033[2m\033[3m";
+$deorphan = ""; // "\033[1m";
+$reset = "\033[22m\033[23m\033[24m";
 
 foreach (@$argv as $a)
 {
@@ -110,7 +115,9 @@ foreach ($lines as $ln)
         else $$var[$c]++;
 
         $varhas = $var."_has";
-        $$varhas[$c][] = $orid;
+        $ligands = count(all_empirical_pairs_for_receptor($orid, true));
+        if ($ligands) $$varhas[$c][] = "$deorphan$orid$reset";
+        else $$varhas[$c][] = "$orphan$orid$reset";
     }
 }
 

--- a/data/conserved.php
+++ b/data/conserved.php
@@ -23,6 +23,8 @@ $orphan = "\033[2m\033[3m";
 $deorphan = ""; // "\033[1m";
 $reset = "\033[22m\033[23m\033[24m";
 
+echo "Legend: {$deorphan}Deorphaned receptor$reset {$orphan}Orphan receptor$reset\n\n";
+
 foreach (@$argv as $a)
 {
 	$a = explode('=',$a,2);
@@ -115,7 +117,7 @@ foreach ($lines as $ln)
         else $$var[$c]++;
 
         $varhas = $var."_has";
-        $ligands = count(all_empirical_pairs_for_receptor($orid, true));
+        $ligands = count(all_empirical_pairs_for_receptor($orid, true, true));
         if ($ligands) $$varhas[$c][] = "$deorphan$orid$reset";
         else $$varhas[$c][] = "$orphan$orid$reset";
     }

--- a/data/odorutils.php
+++ b/data/odorutils.php
@@ -193,7 +193,7 @@ function all_empirical_pairs_for_receptor($protein, $return_1dim = false)
 			{
 				if (!isset($array[$oid]))
 				{
-					if ($acv[$protein]['type'] == 'na') $acv[$protein]['adjusted_curve_top'] = 0;
+					if (@$acv[$protein]['type'] == 'na') $acv[$protein]['adjusted_curve_top'] = 0;
 					$array[$oid] = $acv[$protein];
 					if (isset($array[$oid]['adjusted_curve_top'])) $array[$oid]['top_ref'] = $ref;
 					if (isset($array[$oid]['ec50'])) $array[$oid]['ec50_ref'] = $ref;

--- a/data/odorutils.php
+++ b/data/odorutils.php
@@ -178,7 +178,7 @@ function has_antagonists($protein)
 	return false;
 }
 
-function all_empirical_pairs_for_receptor($protein, $return_1dim = false)
+function all_empirical_pairs_for_receptor($protein, $return_1dim = false, $agonists_only = false)
 {
 	global $odors;
 
@@ -191,6 +191,12 @@ function all_empirical_pairs_for_receptor($protein, $return_1dim = false)
 		{
 			if (isset($acv[$protein]))
 			{
+				if ($agonists_only)
+				{
+					if (isset($acv[$protein]['adjusted_curve_top']) && @$acv[$protein]['adjusted_curve_top'] <= 0) continue;
+					if (@$acv[$protein]['type'] == "na" || @$acv[$protein]['type'] == "ia") continue;
+				}
+
 				if (!isset($array[$oid]))
 				{
 					if (@$acv[$protein]['type'] == 'na') $acv[$protein]['adjusted_curve_top'] = 0;


### PR DESCRIPTION
Orphan receptors now show faint and italicized in the output of data/conserved.php.

No change to docking code.