### PR TITLE
Add received folder to test system

### DIFF
--- a/test/unit_test_express.sh
+++ b/test/unit_test_express.sh
@@ -5,7 +5,6 @@ GRN="\033[38;5;46m"
 NC="\033[0m"
 
 cd "$(dirname "$0")"
-if [ ! -f "../testdata/received" ]; then mkdir -p "../testdata/received"; fi
 cd ..
 
 clear

--- a/test/unit_test_master.sh
+++ b/test/unit_test_master.sh
@@ -5,7 +5,6 @@ GRN="\033[38;5;46m"
 NC="\033[0m"
 
 cd "$(dirname "$0")"
-if [ ! -f "../testdata/received" ]; then mkdir -p "../testdata/received"; fi
 cd ..
 
 clear

--- a/testdata/received/.gitignore
+++ b/testdata/received/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
I had to manually add a received/ folder when running point_report. This PR fixes that.