### PR TITLE
Fix OUTPDB model to show same side chain configurations as dock file.

### DIFF
--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2977,6 +2977,9 @@ void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molec
                     for (q=0; bb[q]; q++)
                     {
                         if (!bb[q]->count_moves_with_btom()) continue;
+                        if (!bb[q]->atom || !bb[q]->btom) continue;         // Sanity check, otherwise we're sure to get random foolish segfaults.
+                        if (bb[q]->atom->is_backbone && strcmp(bb[q]->atom->name, "CA")) continue;
+                        if (bb[q]->btom->is_backbone) continue;
                         float theta;
                         int heavy_atoms = bb[q]->count_heavy_moves_with_btom();
                         if (heavy_atoms && (!(a->movability & MOV_CAN_FLEX) || (a->movability & MOV_FORBIDDEN))) continue;

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -169,7 +169,9 @@ void Pose::restore_state(Molecule* m)
         n = saved_atom_locs.size();
         for (i=0; i<n; i++)
         {
-            if (n != sz || !m->atoms[i] || (saved_atom_Z[i] != m->atoms[i]->get_Z()))
+            // TODO: Arginine residues sometimes end up lacking one of their hydrogens.
+            if (i == n-1 && !m->atoms[i] && (saved_atom_Z[i] == 1)) break;
+            if (/*n != sz ||*/ !m->atoms[i] || (saved_atom_Z[i] != m->atoms[i]->get_Z()))
             {
                 cout << "Attempt to restore pose to incompatible molecule." << endl;
                 throw -4;

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -158,6 +158,7 @@ void Pose::copy_state(Molecule* m)
         saved_atom_locs[i] = m->atoms[i]->get_location();
         saved_atom_Z[i] = m->atoms[i]->get_Z();
     }
+    sz = i;
 }
 
 void Pose::restore_state(Molecule* m)
@@ -171,6 +172,7 @@ void Pose::restore_state(Molecule* m)
         {
             // TODO: Arginine residues sometimes end up lacking one of their hydrogens.
             if (i == n-1 && !m->atoms[i] && (saved_atom_Z[i] == 1)) break;
+            if (!m->atoms[i] && !saved_atom_Z[i]) continue;
             if (/*n != sz ||*/ !m->atoms[i] || (saved_atom_Z[i] != m->atoms[i]->get_Z()))
             {
                 cout << "Attempt to restore pose to incompatible molecule." << endl;

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -170,9 +170,8 @@ void Pose::restore_state(Molecule* m)
         n = saved_atom_locs.size();
         for (i=0; i<n; i++)
         {
-            // TODO: Arginine residues sometimes end up lacking one of their hydrogens.
             if (i == n-1 && !m->atoms[i] && (saved_atom_Z[i] == 1)) break;
-            if (!m->atoms[i] && !saved_atom_Z[i]) continue;
+            if (!m->atoms[i] && !saved_atom_Z[i]) break;
             if (/*n != sz ||*/ !m->atoms[i] || (saved_atom_Z[i] != m->atoms[i]->get_Z()))
             {
                 cout << "Attempt to restore pose to incompatible molecule." << endl;

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -66,6 +66,7 @@ public:
 protected:
     int sz = 0;
     std::vector<Point> saved_atom_locs;
+    std::vector<int> saved_atom_Z;
     Molecule* saved_from = nullptr;
 };
 

--- a/src/classes/protein.cpp
+++ b/src/classes/protein.cpp
@@ -14,6 +14,20 @@ using namespace std;
 float *g_rgnxform_r = nullptr, *g_rgnxform_theta = nullptr, *g_rgnxform_y = nullptr;
 float *g_rgnrot_alpha = nullptr, *g_rgnrot_w = nullptr, *g_rgnrot_u = nullptr;
 
+Protein::Protein()
+{
+    aaptrmin.n = aaptrmax.n = 0;
+
+    residues = nullptr;
+    sequence = nullptr;
+    ca = nullptr;
+    res_reach = nullptr;
+    metals = nullptr;
+
+    int i;
+    for (i=0; i<79; i++) Ballesteros_Weinstein[i] = 0;
+}
+
 Protein::Protein(const char* lname)
 {
     name = lname;

--- a/src/classes/protein.h
+++ b/src/classes/protein.h
@@ -46,6 +46,7 @@ class Protein
 {
 public:
     // Constructors.
+    Protein();
     Protein(const char* name);
     ~Protein();
 

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -3218,7 +3218,7 @@ _try_again:
                             for (j1=1; j1 <= n1; j1++)
                             {
                                 AminoAcid* aa = protein->get_residue(j);
-                                if (aa) tmp_pdb_residue[j+1][j1].restore_state(aa);
+                                if (aa && aa->been_flexed) tmp_pdb_residue[j+1][j1].restore_state(aa);
                             }
                             tmp_pdb_ligand[j+1].restore_state(ligand);
 

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1897,7 +1897,8 @@ int main(int argc, char** argv)
     char* dot = strchr(protid, '.');
     if (dot) *dot = 0;
 
-    protein = new Protein(protid);
+    Protein pose_proteins[poses];
+    protein = &pose_proteins[0]; // new Protein(protid);
     pf = fopen(protfname, "r");
     if (!pf)
     {
@@ -2357,8 +2358,9 @@ _try_again:
         }
 
 
-        delete protein;
-        protein = new Protein(protfname);
+        // delete protein;
+        // protein = new Protein(protfname);
+        protein = &pose_proteins[pose-1];
 
         if (temp_pdb_file.length())
         {
@@ -2487,8 +2489,9 @@ _try_again:
                     }
                 }
 
-                delete protein;
-                protein = new Protein(protafname);
+                // delete protein;
+                // protein = new Protein(protafname);
+                protein = &pose_proteins[pose-1];
                 
                 pf = fopen(protafname, "r");
                 protein->load_pdb(pf);
@@ -3149,6 +3152,7 @@ _try_again:
     pose = 1;
     for (i=1; i<=poses; i++)
     {
+        protein = &pose_proteins[i-1];
         for (j=0; j<poses; j++)
         {
             if (dr[j][0].pose == i && dr[j][0].pdbdat.length())
@@ -3217,8 +3221,8 @@ _try_again:
                             int n1 = protein->get_end_resno();
                             for (j1=1; j1 <= n1; j1++)
                             {
-                                AminoAcid* aa = protein->get_residue(j);
-                                if (aa && aa->been_flexed) tmp_pdb_residue[j+1][j1].restore_state(aa);
+                                AminoAcid* aa = protein->get_residue(j1);
+                                if (aa /* && aa->been_flexed */) tmp_pdb_residue[j+1][j1].restore_state(aa);
                             }
                             tmp_pdb_ligand[j+1].restore_state(ligand);
 


### PR DESCRIPTION
- The Protein objects are now retained until the program finishes, and reused for writing the model PDB(s);
- It was still necessary to save the side chain positions into Pose objects and restore them before writing the model(s);
- The Pose object now allows restoring to a different Molecule* from the original saved-from Molecule*, provided the two molecules have compatible atoms.

All master tests are succeeding.