### PR TITLE
Clash limits.

### DIFF
--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -230,7 +230,7 @@
 #define allow_tethered_rotations 1
 
 // Reject any conformation where any single residue's total clashes exceed this threshold.
-#define individual_clash_limit 5
+#define individual_clash_limit 15
 
 // Overwrite the user supplied pocket center with the loneliest point as determined by
 // distances to the nearest residue atoms to the supplied pocket center.

--- a/src/classes/scoring.cpp
+++ b/src/classes/scoring.cpp
@@ -437,7 +437,7 @@ _btyp_unassigned:
         if (dr.do_output_colors) colorless();
     }
 
-    cout << "Ligand internal energy: " << -dr.ligand_self*dr.energy_mult << endl << endl;
+    output << "Ligand internal energy: " << -dr.ligand_self*dr.energy_mult << endl << endl;
 
     if (dr.miscdata.size())
     {

--- a/src/classes/scoring.cpp
+++ b/src/classes/scoring.cpp
@@ -37,6 +37,8 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
         lmkJmol[i] = limkJmol[i] = lmvdWrepl[i] = limvdWrepl[i] = 0;
     }
 
+    worst_energy = 0;
+
     // if (debug) *debug << "Pose " << pose << " pathnode " << nodeno /*<< " clashes " << clash*/ << endl;
 
     ligand->clear_atom_binding_energies();
@@ -212,6 +214,8 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
         {
             if (lb > 500) lb = 0;
             lmkJmol[metcount] = lb;
+
+            if (-lb > worst_energy) worst_energy = -lb;
         }
 
         #if active_persistence

--- a/src/classes/scoring.cpp
+++ b/src/classes/scoring.cpp
@@ -285,6 +285,7 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
     this->imkJmol    = new float[metcount];
     this->mvdWrepl    = new float[metcount];
     this->imvdWrepl    = new float[metcount];
+    ligand_self = ligand->get_intermol_binding(ligand);
     #if use_trip_switch
     tripswitch  = tripclash;
     #endif
@@ -431,6 +432,8 @@ _btyp_unassigned:
         output << "Total: " << -dr.kJmol*dr.energy_mult << endl << endl;
         if (dr.do_output_colors) colorless();
     }
+
+    cout << "Ligand internal energy: " << -dr.ligand_self*dr.energy_mult << endl << endl;
 
     if (dr.miscdata.size())
     {

--- a/src/classes/scoring.h
+++ b/src/classes/scoring.h
@@ -22,6 +22,7 @@ class DockResult
     float* imkJmol = 0;
     float* mvdWrepl = 0;
     float* imvdWrepl = 0;
+    float ligand_self = 0;
     std::string pdbdat;
     std::string softrock;
     std::string miscdata;

--- a/src/classes/scoring.h
+++ b/src/classes/scoring.h
@@ -23,6 +23,7 @@ class DockResult
     float* mvdWrepl = 0;
     float* imvdWrepl = 0;
     float ligand_self = 0;
+    float worst_energy = 0;
     std::string pdbdat;
     std::string softrock;
     std::string miscdata;

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -3089,6 +3089,20 @@ _try_again:
 
             if (!nodeno)
             {
+                if (dr[drcount][nodeno].ligand_self < -individual_clash_limit)
+                {
+                    // cout << "Internal ligand energy " << -dr[drcount][nodeno].ligand_self << " out of range." << endl << endl;
+                    break;          // Exit nodeno loop.
+                }
+                // else cout << "Internal ligand energy " << -dr[drcount][nodeno].ligand_self << " satisfactory." << endl << endl;
+
+                if (dr[drcount][nodeno].worst_energy < -individual_clash_limit)
+                {
+                    cout << "Least favorable binding energy " << -dr[drcount][nodeno].worst_energy << " out of range." << endl << endl;
+                    break;          // Exit nodeno loop.
+                }
+                else cout << "Least favorable binding energy " << -dr[drcount][nodeno].worst_energy << " satisfactory." << endl << endl;
+
                 if (pose==1) dr[drcount][nodeno].pose = pose;
                 else
                 {

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -2329,6 +2329,8 @@ int main(int argc, char** argv)
 
     found_poses = 0;
     int wrote_acvmx = -1, wrote_acvmr = -1;
+    float l_individual_clash_limit = individual_clash_limit - kJmol_cutoff;
+
 _try_again:
     // srand(0xb00d1cca);
     srand(time(NULL));
@@ -3096,12 +3098,12 @@ _try_again:
                 }
                 // else cout << "Internal ligand energy " << -dr[drcount][nodeno].ligand_self << " satisfactory." << endl << endl;
 
-                if (dr[drcount][nodeno].worst_energy < -individual_clash_limit)
+                if (dr[drcount][nodeno].worst_energy > l_individual_clash_limit)
                 {
-                    cout << "Least favorable binding energy " << -dr[drcount][nodeno].worst_energy << " out of range." << endl << endl;
+                    // cout << "Least favorable binding energy " << dr[drcount][nodeno].worst_energy << " out of range." << endl << endl;
                     break;          // Exit nodeno loop.
                 }
-                else cout << "Least favorable binding energy " << -dr[drcount][nodeno].worst_energy << " satisfactory." << endl << endl;
+                // else cout << "Least favorable binding energy " << dr[drcount][nodeno].worst_energy << " satisfactory." << endl << endl;
 
                 if (pose==1) dr[drcount][nodeno].pose = pose;
                 else


### PR DESCRIPTION
- Outputs ligand self clash as part of each dock result.
- Filters dock results so that the ligand internal clash is never more than individual_clash_limit defined in constants.h.
- Filters dock results so that the least favorable residue-ligand binding energy is not more than individual_clash_limit plus the total energy limit from the config file.