### PR TITLE
More output model fixes.

### DIFF
--- a/data/binding_pocket.json
+++ b/data/binding_pocket.json
@@ -1,4 +1,14 @@
 {
+    "OR2F*":
+    {
+        "odorophores":
+        {
+            "OC(C)C":
+            {
+                "pocket": "3.33 4.60 5.46"
+            }
+        }
+    },
     "OR2M3":
     {
         "odorophores":

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -364,6 +364,7 @@
 #define _dbg_bb_realign 0
 #define _dbg_mol_flexion 0
 #define _dbg_soft_dynamics 0
+#define _dbg_residue_poses 1
 
 #endif
 

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -364,7 +364,7 @@
 #define _dbg_bb_realign 0
 #define _dbg_mol_flexion 0
 #define _dbg_soft_dynamics 0
-#define _dbg_residue_poses 1
+#define _dbg_residue_poses 0
 
 #endif
 

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -174,7 +174,7 @@ void Pose::restore_state(Molecule* m)
             if (!m->atoms[i] && !saved_atom_Z[i]) break;
             if (/*n != sz ||*/ !m->atoms[i] || (saved_atom_Z[i] != m->atoms[i]->get_Z()))
             {
-                cout << "Attempt to restore pose to incompatible molecule." << endl;
+                cout << "Attempt to restore pose to incompatible molecule (from " << saved_from->name << " to " << m->name << ")." << endl;
                 throw -4;
             }
         }

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1912,13 +1912,10 @@ int main(int argc, char** argv)
     if (debug) *debug << "Loaded protein." << endl;
     #endif
 
-    Pose** tmp_pdb_residue = new Pose*[poses+1];
-    for (i=0; i<=poses; i++) tmp_pdb_residue[i] = new Pose[protein->get_end_resno()+1];
-    Pose** tmp_pdb_waters = new Pose*[poses+1];
-    for (i=0; i<=poses; i++) tmp_pdb_waters[i] = new Pose[omaxh2o+1];
-    Pose* tmp_pdb_ligand = new Pose[poses+1];
-    Point** tmp_pdb_metal_locs = new Point*[poses+1];
-    for (i=0; i<=poses; i++) tmp_pdb_metal_locs[i] = new Point[mtlcoords.size()+1];
+    Pose tmp_pdb_residue[poses+1][protein->get_end_resno()+1];
+    Pose tmp_pdb_waters[poses+1][omaxh2o+1];
+    Pose tmp_pdb_ligand[poses+1];
+    Point tmp_pdb_metal_locs[poses+1][mtlcoords.size()+1];
 
     if (tplset)
     {

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -8,6 +8,7 @@
 #include <time.h>
 #include <sstream>
 #include <algorithm>
+#include <unistd.h>
 #include "classes/dynamic.h"
 #include "classes/group.h"
 #include "classes/protein.h"
@@ -93,6 +94,7 @@ int triesleft = 0;				// Default is no retry.
 bool echo_progress = false;
 bool hydrogenate_pdb = false;
 std::string temp_pdb_file = "";
+int pid = getpid();
 bool append_pdb = false;
 bool do_output_colors = false;
 
@@ -1948,7 +1950,7 @@ int main(int argc, char** argv)
         }
         else protein->homology_conform(ptemplt, protein);
 
-        temp_pdb_file = "tmp/homolog.pdb";
+        temp_pdb_file = (std::string)"tmp/" + std::to_string(pid) + (std::string)"_homolog.pdb";
 
         pf = fopen(temp_pdb_file.c_str(), "wb");
         protein->save_pdb(pf);
@@ -1964,7 +1966,7 @@ int main(int argc, char** argv)
             if (res) res->hydrogenate();
         }
 
-        temp_pdb_file = "tmp/hydro.pdb";
+        temp_pdb_file = (std::string)"tmp/" + std::to_string(pid) + (std::string)"_hydro.pdb";
 
         pf = fopen(temp_pdb_file.c_str(), "wb");
         protein->save_pdb(pf);
@@ -2075,7 +2077,7 @@ int main(int argc, char** argv)
             }
         }
 
-        temp_pdb_file = "tmp/metal.pdb";
+        temp_pdb_file = (std::string)"tmp/" + std::to_string(pid) + (std::string)"_metal.pdb";
 
         pf = fopen(temp_pdb_file.c_str(), "wb");
         protein->save_pdb(pf);
@@ -2086,7 +2088,7 @@ int main(int argc, char** argv)
     {
         reconnect_bridges();
 
-        temp_pdb_file = "tmp/bridged.pdb";
+        temp_pdb_file = (std::string)"tmp/" + std::to_string(pid) + (std::string)"_bridged.pdb";
 
         pf = fopen(temp_pdb_file.c_str(), "wb");
         protein->save_pdb(pf);
@@ -3355,6 +3357,8 @@ _exitposes:
         }
         else cout << "ERROR: Append PDB can only be used when specifying an output file." << endl;
     }
+
+    if (temp_pdb_file.length()) std::remove(temp_pdb_file.c_str());
 
     if (debug) debug->close();
 

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -2927,7 +2927,13 @@ _try_again:
                 for (j=1; j <= n; j++)
                 {
                     AminoAcid* aa = protein->get_residue(j);
-                    if (aa) tmp_pdb_residue[pose][j].copy_state(aa);
+                    if (aa)
+                    {
+                        tmp_pdb_residue[pose][j].copy_state(aa);
+                        #if _dbg_residue_poses
+                        cout << "tmp_pdb_residue[" << pose << "][" << j << "].copy_state(" << aa->get_name() << ")" << endl;
+                        #endif
+                    }
                 }
                 if (waters)
                 {
@@ -3238,7 +3244,13 @@ _try_again:
                             for (j1=1; j1 <= n1; j1++)
                             {
                                 AminoAcid* aa = protein->get_residue(j1);
-                                if (aa /* && aa->been_flexed */) tmp_pdb_residue[j+1][j1].restore_state(aa);
+                                if (aa /* && aa->been_flexed */)
+                                {
+                                    tmp_pdb_residue[j+1][j1].restore_state(aa);
+                                    #if _dbg_residue_poses
+                                    cout << "tmp_pdb_residue[" << (j+1) << "][" << j1 << "].restore_state(" << aa->get_name() << ")" << endl;
+                                    #endif
+                                }
                             }
                             tmp_pdb_ligand[j+1].restore_state(ligand);
 

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1912,10 +1912,13 @@ int main(int argc, char** argv)
     if (debug) *debug << "Loaded protein." << endl;
     #endif
 
-    Pose tmp_pdb_residue[poses+1][protein->get_end_resno()+1];
-    Pose tmp_pdb_waters[poses+1][omaxh2o+1];
-    Pose tmp_pdb_ligand[poses+1];
-    Point tmp_pdb_metal_locs[poses+1][mtlcoords.size()+1];
+    Pose** tmp_pdb_residue = new Pose*[poses+1];
+    for (i=0; i<=poses; i++) tmp_pdb_residue[i] = new Pose[protein->get_end_resno()+1];
+    Pose** tmp_pdb_waters = new Pose*[poses+1];
+    for (i=0; i<=poses; i++) tmp_pdb_waters[i] = new Pose[omaxh2o+1];
+    Pose* tmp_pdb_ligand = new Pose[poses+1];
+    Point** tmp_pdb_metal_locs = new Point*[poses+1];
+    for (i=0; i<=poses; i++) tmp_pdb_metal_locs[i] = new Point[mtlcoords.size()+1];
 
     if (tplset)
     {


### PR DESCRIPTION
Tracking down a very strange bug.

The `tmp_pdb_residue` array, a stack allocation, is populated with the positions of residue atoms (using .copy_state()) very soon after docking a pose. Later on, the residue atom positions may have changed (TODO: why?) so their positions are returned to those from the dock result using .restore_state().

To prevent any possibility of mangling the locations of atoms, the molecule passed to ::restore_state() must be the same molecule or a compatible molecule to that passed to ::copy_state().

The problem is if a dock is running for one protein, say OR2F1, and other docks are running for a different protein, such as OR51E2, the `tmp_pdb_residue` array for OR2F1 is getting corrupted with residues from OR51E2 - from an entirely separate process - and ::restore_state() is failing because it "thinks" the atoms should be OR51E2's atoms.