### PR TITLE
MEASURE command for finding interatomic distances in Pepteditor.

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -492,6 +492,18 @@ Yar or YO before the metal symbol applies globally to the coordination residues.
 overriding the default or any global.
 
 
+# MEASURE
+
+Example:
+```
+MEASURE 180 257 &distance                   # Measure the distance between CA atoms.
+MEASURE %6.55 %45.51 &distance              # Same thing but using BW numbering.
+MEASURE %5.58 "OH" %7.53 "OH" &distance     # Specify atoms whose locations to measure.
+```
+
+Computes the distance in Angstroms between any two residues, or any two atoms of the current working protein, and stores the result in an output variable.
+
+
 # MOVE
 # MOVEREL
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -2303,6 +2303,31 @@ int main(int argc, char** argv)
 
             } // MCOORD
 
+            else if (!strcmp(words[0], "MEASURE"))
+            {
+                for (l=1; words[l]; l++);       // Count params.
+
+                if (l != 4 && l != 6) raise_error("Wrong number of parameters given for MEASURE.");
+
+                bool atom_names = (l >= 5);
+                int res1 = interpret_single_int(words[1]);
+                std::string atom1 = atom_names ? interpret_single_string(words[2]) : "CA";
+                int res2 = interpret_single_int(words[atom_names ? 3 : 2]);
+                std::string atom2 = atom_names ? interpret_single_string(words[4]) : "CA";
+
+                if (!res1 || !working->get_residue(res1)) raise_error("Residue A not found in protein.");
+                if (!res2 || !working->get_residue(res2)) raise_error("Residue B not found in protein.");
+
+                if (!working->get_atom(res1, atom1.c_str())) raise_error(std::to_string(res1) + (std::string)":" + atom1 + (std::string)" not found in protein.");
+                if (!working->get_atom(res2, atom2.c_str())) raise_error(std::to_string(res2) + (std::string)":" + atom2 + (std::string)" not found in protein.");
+
+                float r = working->get_atom_location(res1, atom1.c_str()).get_3d_distance(working->get_atom_location(res2, atom2.c_str()));
+
+                Star s;
+                s.f = r;
+                set_variable(words[l-1], s);
+            } // MEASURE
+
             else if (!strcmp(words[0], "MOVE"))
             {
                 l = 1;

--- a/test/measure.pepd
+++ b/test/measure.pepd
@@ -1,0 +1,9 @@
+
+LOAD pdbs/OR51/OR51E2.8f76.pdb
+
+ECHO %5.58 "~" %7.53 ~
+
+MEASURE %5.58 "OH" %7.53 "OH" &r
+
+ECHO ": atoms are " &r "A apart."
+

--- a/test/unit_test_express.sh
+++ b/test/unit_test_express.sh
@@ -74,6 +74,18 @@ else
     diff --color --unified $REPORT testdata/received/ifnot_test.received.txt
 fi
 
+
+REPORT="testdata/measure_test.approved.txt"
+./bin/pepteditor test/measure.pepd | sed '/^#/d' >testdata/received/measure_test.received.txt
+RESULT=$(diff --unified $REPORT testdata/received/measure_test.received.txt)
+if [ -z "$RESULT" ]; then
+    printf "${GRN}\u2588${NC}"
+else
+    printf "\n${RED}MEASURE test FAILED.${NC}\n"
+    diff --color --unified $REPORT testdata/received/measure_test.received.txt
+fi
+
+
 REPORT="testdata/bwmagic.approved.txt"
 bin/pepteditor test/bwmagic.pepd | sed '/^#/d' >testdata/received/bwmagic.received.txt
 RESULT=$(diff --unified $REPORT testdata/received/bwmagic.received.txt)

--- a/testdata/measure_test.approved.txt
+++ b/testdata/measure_test.approved.txt
@@ -1,0 +1,1 @@
+217~291: atoms are 3.934409A apart.


### PR DESCRIPTION
There is now a `MEASURE` command which takes two residues, or two pairs of residue and atom name, as arguments, followed by an output variable of type float. Its function is to measure the distance in Angstroms between the two atoms and store the result in the output var.