### PR TITLE
Predict non-agonist if no poses.

### DIFF
--- a/predict/method_icactive.php
+++ b/predict/method_icactive.php
@@ -55,6 +55,12 @@ function make_prediction($data)
 
         echo "\nResult: " . print_r($data, true) . "\n";
     }
+    else if (isset($data["a_POSES"]) && !$data["a_POSES"])
+    {
+        $data['Predicted'] = 'Non-agonist';
+        $data['DockScore'] = 0.0;
+        echo "\nResult: " . print_r($data, true) . "\n";
+    }
 
     return $data;
 }


### PR DESCRIPTION
If docking produces no active conformation poses, write a prediction of non-agonist and a dock score of zero to the dock results JSON file.