### PR TITLE
CH...O hydrogen bonding.

### DIFF
--- a/data/bindings.dat
+++ b/data/bindings.dat
@@ -99,6 +99,9 @@ OH      S      hbond    0.25  2.8?        4?          5
 SH      S      hbond    0.25  2.8?        4?          5
 FH      F      hbond    0.5   2.0?      161.5         ?
 
+# https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3516709/
+CH      O      hbond    0.25  1.6?        2.1         1.6?
+
 # https://pubs.acs.org/doi/abs/10.1021/jz502150d?source=cen
 OH      P      hbond    0.5   2.6        18           11?
 
@@ -204,7 +207,7 @@ S       Zn     coord    0.5   2.43       24.0           2.5
 # To be expanded later.
 # Keep these last or the code will erroneously add them to the other bindings.
 *		C	   vdW		0.1	  4.0		  0.4
-*		H	   vdW		0.1	  3.0		  0.4
+*       H 	   vdW		0.1	  3.0		  0.4
 
 
 

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -1130,7 +1130,7 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
                 partial *= achg * -bchg;
             }
 
-            if (forces[i]->type == hbond) partial *= fabs(apol) * fabs(bpol);
+            if (forces[i]->type == hbond && fabs(apol) && fabs(bpol)) partial *= fabs(apol) * fabs(bpol);
 
             # if 0
             //if (forces[i]->type == polarpi || forces[i]->type == mcoord)


### PR DESCRIPTION
https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3516709/

Weak hydrogen bonds are possible between "nonpolar" C-H functional groups and oxygen atoms. Hydrogen bonding occurs when a hydrogen nucleus (proton), partially unshielded by the greater electronegativity of its bonded atom, is attracted to an unbonded electron lone pair of a nitrogen, oxygen, halogen, or (rarely) sulfur, phosphorus, selenium, etc. atom.

Hydrogen's electronegativity is 2.2 while carbon's is 2.55, making the C-H bond slightly polar with a relative polar strength of 0.35 compared to 0.38 for S-H, 0.84 for N-H, 1.24 for O-H, and 1.78 for F-H. Therefore, hydrogen bonds involving carbon-bonded hydrogens would be weak, but not nonexistent. Importantly, while the C-H bonds in a hydrocarbon may have weak polarity, the molecule as a whole is nonpolar because the slight positive partial charges of their hydrogens are distributed symmetrically over their molecular surface.

The cited reference above provides evidence of CH ... O hydrogen bonding. This PR approximates the empirical findings in order to more accurately compute ligand-protein interaction strengths.