### PR TITLE
Staggered vs eclipsed hydrogens

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ OBJS=$(OBJDIR)/misc.o $(OBJDIR)/point.o $(OBJDIR)/atom.o $(OBJDIR)/intera.o $(OB
 	$(OBJDIR)/protein.o $(OBJDIR)/group.o $(OBJDIR)/dynamic.o $(OBJDIR)/moiety.o $(OBJDIR)/scoring.o $(OBJDIR)/conj.o
 TESTS=test/point_test test/atom_test test/molecule_test test/pi_stack_test test/mol_assem_test test/aniso_test test/amino_test \
 	  test/group_test_mol test/group_test_res test/protein_test test/backbone_test test/bond_rotation_test test/moiety_test \
-	  test/flexion_test test/histidine_test test/ring_test
+	  test/flexion_test test/histidine_test test/ring_test test/eclipsing_test
 APPS=$(BINDIR)/primarydock $(BINDIR)/pepteditor $(BINDIR)/ic $(BINDIR)/ic_activate_or $(BINDIR)/fyg_activate_or \
 	 $(BINDIR)/score_pdb $(BINDIR)/ramachandran
 REPORTS=amino_report atom_report aniso_report point_report molecule_report mol_assem_report protein_report motif_report
@@ -113,6 +113,9 @@ test/moiety_test: src/moiety_test.cpp $(OBJS)
 
 test/mol_assem_test: src/mol_assem_test.cpp $(OBJS)
 	$(CC) src/mol_assem_test.cpp $(OBJS) -o test/mol_assem_test $(CFLAGS)
+
+test/eclipsing_test: src/eclipsing_test.cpp $(OBJS)
+	$(CC) src/eclipsing_test.cpp $(OBJS) -o test/eclipsing_test $(CFLAGS)
 
 test/amino_test: src/amino_test.cpp $(OBJS) $(OBJDIR)/aminoacid.o
 	$(CC) src/amino_test.cpp $(OBJS) -o test/amino_test $(CFLAGS)

--- a/predict/center.pepd
+++ b/predict/center.pepd
@@ -50,7 +50,7 @@ LET &x1 = &xm - &xa
 LET &x2 = &xa - &xi
 LET &x = &x1
 IF &x2 > &x1 LET &x = &x2
-LET @size.x = &x * 2
+LET @size.x = &x
 
 LET &ym = @max.y
 LET &yi = @min.y
@@ -59,7 +59,7 @@ LET &y1 = &ym - &ya
 LET &y2 = &ya - &yi
 LET &y = &y1
 IF &y2 > &y1 LET &y = &y2
-LET @size.y = &y * 2
+LET @size.y = &y
 
 LET &zm = @max.z
 LET &zi = @min.z
@@ -68,7 +68,7 @@ LET &z1 = &zm - &za
 LET &z2 = &za - &zi
 LET &z = &z1
 IF &z2 > &z1 LET &z = &z2
-LET @size.z = &z * 2
+LET @size.z = &z
 
 
 # Output.

--- a/predict/fyg_activate_or.php
+++ b/predict/fyg_activate_or.php
@@ -11,6 +11,17 @@ foreach ($prots as $protid => $prot)
 {
     if (isset($argv[1]) && $protid != $argv[1] && !preg_match("/^{$argv[1]}$/", $protid)) continue;
     $fam = family_from_protid($protid);
+
+    if (substr($fam, 0, 2) == "OR")
+    {
+        $fno = intval(substr($fam, 2));
+        if ($fno == 51 || $fno == 52)
+        {
+            if (@$argv[1] == $protid) die("OR51 and OR52 receptors should use the direct model method.\n");
+            else continue;
+        }
+    }
+
     $pdbfname_active = "pdbs/$fam/$protid.active.pdb";
     if (!file_exists($pdbfname_active) || filemtime($pdbfname_active) < filemtime("bin/fyg_activate_or") || $protid == @$argv[1])
     {

--- a/predict/method_directmdl.php
+++ b/predict/method_directmdl.php
@@ -16,9 +16,9 @@ chdir(__DIR__);
 
 // Configurable variables
 $flex = 1;                      // Flexion (0 or 1).
-$pose = 15;
+$pose = 5;
 $iter = 30;
-$elim = 1e33;                    // Energy limit for poses. (Not the tailor/spy from the space station.)
+$elim = 1e18;                    // Energy limit for poses. (Not the tailor/spy from the space station.)
 $num_std_devs = 2.0;            // How many standard deviations to move the helices for active clash compensation.
 
 prepare_outputs();

--- a/predict/method_directmdl.php
+++ b/predict/method_directmdl.php
@@ -18,7 +18,7 @@ chdir(__DIR__);
 $flex = 1;                      // Flexion (0 or 1).
 $pose = 15;
 $iter = 30;
-$elim = 1e3;                    // Energy limit for poses. (Not the tailor/spy from the space station.)
+$elim = 1e33;                    // Energy limit for poses. (Not the tailor/spy from the space station.)
 $num_std_devs = 2.0;            // How many standard deviations to move the helices for active clash compensation.
 
 prepare_outputs();

--- a/predict/method_directmdl.php
+++ b/predict/method_directmdl.php
@@ -78,12 +78,14 @@ $paramfname = str_replace(".upright.pdb", ".params", $pdbfname);
 if (!file_exists($pdbfname_inactive) && file_exists($pdbfname_active))
     $pdbfname_inactive = $pdbfname;
 
-if (!file_exists($pdbfname_active))
+if (!file_exists($pdbfname_active) && (substr($protid, 0, 4) == "OR51" || substr($protid, 0, 4) == "OR52"))
 {
     exec("php -f predict/cryoem_motions.php");
     exec("bin/pepteditor data/OR51.pepd");
     exec("bin/pepteditor data/OR52.pepd");
 }
+
+if (!file_exists($pdbfname_active)) die("No bound model.\n");
 
 $flex_constraints = "";
 if (file_exists($paramfname)) $flex_constraints = file_get_contents($paramfname);

--- a/predict/method_directmdl.php
+++ b/predict/method_directmdl.php
@@ -116,7 +116,8 @@ prepare_receptor($pdbfname, "$flxr $aflxr");
 
 $poses = process_dock("a");
 
-if ((!$poses || $best_energy >= 0) && count($clashcomp) && $num_std_devs)
+// TODO: Separate dynamic_clash_compensation() into FYG-activation and direct-model editions.
+/* if ((!$poses || $best_energy >= 0) && count($clashcomp) && $num_std_devs)
 {
     dynamic_clash_compensation();
 
@@ -127,5 +128,4 @@ if ((!$poses || $best_energy >= 0) && count($clashcomp) && $num_std_devs)
 
     // Delete the tmp PDB.
     unlink($tmpoutpdb);
-}
-
+} */

--- a/predict/method_directmdl.php
+++ b/predict/method_directmdl.php
@@ -16,9 +16,9 @@ chdir(__DIR__);
 
 // Configurable variables
 $flex = 1;                      // Flexion (0 or 1).
-$pose = 5;
+$pose = 15;
 $iter = 30;
-$elim = 1e18;                    // Energy limit for poses. (Not the tailor/spy from the space station.)
+$elim = 1e3;                    // Energy limit for poses. (Not the tailor/spy from the space station.)
 $num_std_devs = 2.0;            // How many standard deviations to move the helices for active clash compensation.
 
 prepare_outputs();

--- a/predict/method_directmdl.php
+++ b/predict/method_directmdl.php
@@ -111,3 +111,17 @@ $cenres = substr($cenres_active, 8);
 prepare_receptor($pdbfname, "$flxr $aflxr");
 
 $poses = process_dock("a");
+
+if ((!$poses || $best_energy >= 0) && count($clashcomp) && $num_std_devs)
+{
+    dynamic_clash_compensation();
+
+    $pdbfname = $tmpoutpdb;
+    $outfname = "output/$fam/$protid/$protid.$ligname.dynamic.dock";
+    prepare_receptor($pdbfname, "$flxr $aflxr");
+    $poses = process_dock("ad");
+
+    // Delete the tmp PDB.
+    unlink($tmpoutpdb);
+}
+

--- a/predict/method_directmdl.php
+++ b/predict/method_directmdl.php
@@ -13,6 +13,8 @@ require_once("methods_common.php");
 chdir(__DIR__);
 require_once("../data/protutils.php");
 chdir(__DIR__);
+require_once("template.php");
+chdir(__DIR__);
 
 // Configurable variables
 $flex = 1;                      // Flexion (0 or 1).

--- a/predict/template.php
+++ b/predict/template.php
@@ -234,7 +234,7 @@ function dynamic_clash_compensation()
         }
     }
 
-    // Create a temporary custom output PDB and retry the active dock.
+    // Create a temporary custom output PDB in order to retry the active dock.
     $args = "$protid";
     foreach ($template as $hxno => $metrics)
     {

--- a/predict/template.php
+++ b/predict/template.php
@@ -156,3 +156,105 @@ function do_templated_activation()
         }
     }
 }
+
+function dynamic_clash_compensation()
+{
+    global $protid, $has_fyg, $has_rock6, $cryoem, $template, $clashcomp, $num_std_devs, $tmpoutpdb;
+    if (!count($template)) build_template();
+
+    // Ensure template contains standard deviations. If not, average the ones from the templates that do.
+    foreach ($template as $hxno => $metrics)
+    {
+        foreach ($metrics as $metric => $xyz)
+        {
+            if (!isset($xyz["sigma"]))
+            {
+                $averages = [];
+                $counts = [];
+
+                foreach ($cryoem as $lrecep => $lhelixes)
+                {
+                    foreach ($lhelixes as $lhelix => $lmetrics)
+                    {
+                        foreach ($lmetrics as $lmetric => $lxyz)
+                        {
+                            if (isset($lxyz["sigma"]))
+                            {
+                                if (!isset($averages[$lhelix][$lmetric])) $averages[$lhelix][$lmetric] = floatval($lxyz["sigma"]);
+                                else $averages[$lhelix][$lmetric] += floatval($lxyz["sigma"]);
+
+                                if (!isset($counts[$lhelix][$lmetric])) $counts[$lhelix][$lmetric] = 1;
+                                else $counts[$lhelix][$lmetric]++;
+                            }
+                        }
+                    }
+                }
+
+                foreach ($averages as $lhelix => $lmetrics)
+                {
+                    foreach ($lmetrics as $lmetric => $total)
+                    {
+                        if (!isset($template[$lhelix][$lmetric]["sigma"]))
+                        {
+                            if ($counts[$lhelix][$lmetric]) $total /= $counts[$lhelix][$lmetric];
+                            $template[$lhelix][$lmetric]["sigma"] = $total;
+                        }
+                    }
+                }
+
+                break;
+            }
+        }
+    }
+
+    foreach ($clashcomp as $tmrno => $cc)
+    {
+        foreach ($cc as $segment => $xyz)
+        {
+            // Check each clash compensation is within the SD limit. If not, reduce the magnitude to the deviation limit.
+            $sigma = floatval(@$template[$tmrno][$segment]["sigma"]);
+            $rlimit = $sigma*$num_std_devs;
+            if (!$sigma) continue;
+            $tmparr = []; foreach (['x','y','z'] as $idx => $var) $tmparr[$var] = floatval($xyz[$idx]); extract($tmparr);
+            $r = sqrt($x*$x+$y*$y+$z*$z);
+
+            if ($r > $rlimit)
+            {
+                $divisor = $rlimit / $r;
+                $x *= $divisor; $y *= $divisor; $z *= $divisor;
+            }
+
+            // Apply the corrected compensation.
+            foreach (['x','y','z'] as $var)
+            {
+                $$var = round($$var, 3);
+                $template[$tmrno][$segment][$var] = floatval($template[$tmrno][$segment][$var]) + $$var;
+                echo "Compensating TMR$tmrno.$segment.$var to {$template[$tmrno][$segment][$var]}...\n";
+            }
+        }
+    }
+
+    // Create a temporary custom output PDB and retry the active dock.
+    $args = "$protid";
+    foreach ($template as $hxno => $metrics)
+    {
+        foreach ($metrics as $metric => $dimensions)
+        {
+            if ($hxno == 6)
+            {
+                if ($metric == "cyt" && ($has_fyg || $has_rock6)) continue;
+                else if ($metric == "exr" && $has_rock6) continue;
+            }
+
+            $cmdarg = "--" . substr($metric, 0, 1) . $hxno;
+            $args .= " $cmdarg {$dimensions['x']} {$dimensions['y']} {$dimensions['z']}";
+        }
+    }
+
+    $tmpoutpdb = "tmp/$protid.".getmypid().".pdb";
+    $args .= " -o $tmpoutpdb";
+
+    $cmd = "bin/fyg_activate_or $args";
+    echo "$cmd\n";
+    passthru($cmd);
+}

--- a/src/classes/aminoacid.cpp
+++ b/src/classes/aminoacid.cpp
@@ -1395,6 +1395,8 @@ _return_added:
     if (!check_Greek_continuity()) throw 0xbadc0de;
     #endif
 
+    initial_eclipses = total_eclipses();
+
     return added;
 }
 

--- a/src/classes/aminoacid.h
+++ b/src/classes/aminoacid.h
@@ -184,6 +184,7 @@ public:
     MetalCoord* m_mcoord=0;
     Atom* coordmtl = nullptr;
     bool added_heavies = false;
+    float initial_eclipses = 0;
 
 protected:
     void load_aa_defs();

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -123,7 +123,7 @@
 #define global_clash_allowance 0.4
 #define double_hydrogen_clash_allowance_multiplier 1.5
 #define ignore_double_hydrogen_clashes 0
-#define ignore_nonpolar_hydrogen_clashes 1
+#define ignore_nonpolar_hydrogen_clashes 0
 #define Lennard_Jones_epsilon 1.0
 #define Lennard_Jones_epsilon_x4 Lennard_Jones_epsilon*4
 #define lmpush 3.0

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -26,6 +26,7 @@
 #define unconnected_residue_mindist 4.82
 #define clash_limit_per_aa 4.0
 #define contact_r_5x58_7x53 3.93
+#define eclipsing_kJmol_per_radian 1.86453
 #define memsanity 0x10000000
 
 #define pH 6.0
@@ -355,6 +356,7 @@
 #define _dbg_cond_basic_acd_lig 0
 #define _dbg_conj_chg 0
 #define _dbg_conjugation 0
+#define _dbg_eclipses 0
 #define _dbg_find_blasted_segfault 0
 #define _dbg_fitness_plummet 0
 #define _dbg_flexion_selection 0

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -3147,6 +3147,8 @@ float Molecule::cfmol_multibind(Molecule* a, Molecule** nearby)
     if (a->is_residue() && ((AminoAcid*)a)->conditionally_basic()) ((AminoAcid*)a)->set_conditional_basicity(nearby);
 
     float result = -a->total_eclipses();
+    if (a->is_residue()) result += reinterpret_cast<AminoAcid*>(a)->initial_eclipses;
+
     int j;
     for (j=0; nearby[j]; j++)
     {

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -666,23 +666,27 @@ float Molecule::total_eclipses()
         n = atoms[i]->get_geometry();
         for (j=0; j<n; j++)
         {
+            if (!abt[j]) continue;
             if (abt[j]->cardinality > 1) continue;
             if (!abt[j]->can_rotate) continue;
             if (!abt[j]->btom) continue;
             if (abt[j]->btom->get_Z() < 2) continue;
             if (atoms[i]->is_pi() && abt[j]->btom->is_pi()) continue;
+            if (atoms[i]->is_backbone && abt[j]->btom->is_backbone) continue;
             SCoord axis = abt[j]->btom->get_location().subtract(atoms[i]->get_location());
             Bond* bbt[16];
             abt[j]->btom->fetch_bonds(bbt);
             m = abt[j]->btom->get_geometry();
             for (k=0; k<m; k++)
             {
+                if (!bbt[k]) continue;
                 if (!bbt[k]->btom) continue;
                 if (bbt[k]->btom == atoms[i]) continue;
                 for (l=0; l<n; l++)
                 {
-                    if (!abt[l]->btom) continue;
                     if (l == j) continue;
+                    if (!abt[l]) continue;
+                    if (!abt[l]->btom) continue;
                     float theta = find_angle_along_vector(bbt[k]->btom->get_location(), abt[l]->btom->get_location(), atoms[i]->get_location(), axis);
                     if (theta >= -hexagonal && theta <= hexagonal)
                     {
@@ -3146,7 +3150,7 @@ float Molecule::cfmol_multibind(Molecule* a, Molecule** nearby)
     int j;
     for (j=0; nearby[j]; j++)
     {
-        float f = a->intermol_bind_for_multimol_dock(nearby[j], false);
+        float f = a->intermol_bind_for_multimol_dock(nearby[j], false) - a->total_eclipses();
         result += f;
     }
     if (a->mclashables)

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -3146,11 +3146,11 @@ float Molecule::cfmol_multibind(Molecule* a, Molecule** nearby)
 {
     if (a->is_residue() && ((AminoAcid*)a)->conditionally_basic()) ((AminoAcid*)a)->set_conditional_basicity(nearby);
 
-    float result = 0;
+    float result = -a->total_eclipses();
     int j;
     for (j=0; nearby[j]; j++)
     {
-        float f = a->intermol_bind_for_multimol_dock(nearby[j], false) - a->total_eclipses();
+        float f = a->intermol_bind_for_multimol_dock(nearby[j], false);
         result += f;
     }
     if (a->mclashables)

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -124,6 +124,7 @@ public:
     bool shielded(Atom* a, Atom* b) const;
     float correct_structure(int iters = 500);
     float close_loop(Atom** path, float closing_bond_cardinality);
+    float total_eclipses();
     void crumple(float theta);					// Randomly rotate all rotatable bonds by +/- the specified angle.
     float distance_to(Molecule* other_mol);
     std::vector<Atom*> longest_dimension();

--- a/src/classes/scoring.cpp
+++ b/src/classes/scoring.cpp
@@ -222,7 +222,7 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
             res_clash_dir[resno] = res_clash_dir[resno].add(clashdir);
         }
 
-        lb -= reaches_spheroid[i]->total_eclipses() - reaches_spheroid[i]->initial_eclipses;
+        lb -= fmax(reaches_spheroid[i]->total_eclipses() - reaches_spheroid[i]->initial_eclipses, 0);
 
         #if _dbg_51e2_ionic
         if (resno == 262)

--- a/src/classes/scoring.cpp
+++ b/src/classes/scoring.cpp
@@ -222,6 +222,8 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
             res_clash_dir[resno] = res_clash_dir[resno].add(clashdir);
         }
 
+        lb -= reaches_spheroid[i]->total_eclipses() - reaches_spheroid[i]->initial_eclipses;
+
         #if _dbg_51e2_ionic
         if (resno == 262)
         {
@@ -319,7 +321,7 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
     this->imvdWrepl    = new float[metcount];
     this->m_atom1_name  = new const char*[metcount];
     this->m_atom2_name  = new const char*[metcount];
-    ligand_self = ligand->get_intermol_binding(ligand);
+    ligand_self = ligand->get_intermol_binding(ligand) - ligand->total_eclipses();
     kJmol += ligand_self;
     #if _dbg_internal_energy
     cout << "Ligand internal = " << ligand_self << endl;

--- a/src/eclipsing_test.cpp
+++ b/src/eclipsing_test.cpp
@@ -1,0 +1,30 @@
+
+#include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <cstring>
+#include "classes/molecule.h"
+
+using namespace std;
+
+int main(int argc, char** argv)
+{
+    Molecule m("Test");
+    m.from_smiles("CC");
+
+    FILE* fp = fopen("testdata/staggered.sdf", "wb");
+    if (!fp) return -1;
+    m.save_sdf(fp);
+    fclose(fp);
+    Atom *C1 = m.get_atom("C1"), *C2 = m.get_atom("C2");
+    if (!C1 || !C2) return -1;
+    Bond *b = C1->get_bond_between(C2);
+    if (!b) return -1;
+
+    b->rotate(hexagonal);
+    fp = fopen("testdata/eclipsed.sdf", "wb");
+    if (!fp) return -1;
+    m.save_sdf(fp);
+    fclose(fp);
+}

--- a/src/eclipsing_test.cpp
+++ b/src/eclipsing_test.cpp
@@ -12,17 +12,23 @@ int main(int argc, char** argv)
 {
     Molecule m("Test");
     m.from_smiles("CC");
+    float e = m.total_eclipses();
+    cout << "Initial eclipses: " << e << endl;
 
     FILE* fp = fopen("testdata/staggered.sdf", "wb");
     if (!fp) return -1;
     m.save_sdf(fp);
     fclose(fp);
+
     Atom *C1 = m.get_atom("C1"), *C2 = m.get_atom("C2");
     if (!C1 || !C2) return -1;
     Bond *b = C1->get_bond_between(C2);
     if (!b) return -1;
 
     b->rotate(hexagonal);
+    e = m.total_eclipses();
+    cout << "Final eclipses: " << e << endl;
+
     fp = fopen("testdata/eclipsed.sdf", "wb");
     if (!fp) return -1;
     m.save_sdf(fp);

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -3059,7 +3059,7 @@ _try_again:
 
             if (!nodeno)
             {
-                if (dr[drcount][nodeno].ligand_self < -individual_clash_limit)
+                if ((dr[drcount][nodeno].ligand_self + ligand->total_eclipses()) < -individual_clash_limit)
                 {
                     // cout << "Internal ligand energy " << -dr[drcount][nodeno].ligand_self << " out of range." << endl << endl;
                     break;          // Exit nodeno loop.


### PR DESCRIPTION
When bonds rotate such that atoms are placed in eclipsed positions rather than staggered, there is a loss of energetic favorability (an increase in energy) of about 11 kJ/mol. This energy cost can affect whether a receptor is sensitive to a ligand because it may be necessary for either the ligand or a side chain to flex in order to fit the ligand in the binding pocket. So even if a ligand fits the active receptor and forms good contacts, if the energy cost is greater than the difference between active and inactive binding energies, then the active conformation will not be favored and the ligand will not be an agonist.

This PR addresses the effect of eclipsing atoms and successfully distinguishes caproic and oenanthic acids as non-agonists of OR51E2 while maintaining propionic acid as an agonist.

![image](https://github.com/primaryodors/primarydock/assets/106125032/efbc5195-093d-432b-a65f-16a95e688736)
