### PR TITLE
Prevent multiple connected atoms from unnaturally amplifying ionic bonds.

### DIFF
--- a/src/classes/conj.h
+++ b/src/classes/conj.h
@@ -21,6 +21,8 @@ class Conjugation
     Atom* get_nearest_atom(Point pt);
     Atom* get_nearest_atom(Conjugation* conj);
 
+    bool spent = false;
+
     protected:
     Atom** atoms = nullptr;           // Not using a vector for performance reasons.
     float net_charge = 0;

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -345,6 +345,9 @@ void InteratomicForce::fetch_applicable(Atom* a, Atom* b, InteratomicForce** ret
         }
         else if (a->conjugation && a != a->conjugation->get_nearest_atom(b->get_location())) do_ionic = false;
         else if (b->conjugation && b != b->conjugation->get_nearest_atom(a->get_location())) do_ionic = false;
+
+        if (a->conjugation && a->conjugation->spent) do_ionic = false;
+        if (b->conjugation && b->conjugation->spent) do_ionic = false;
     }
     if (do_ionic)
     {
@@ -740,6 +743,9 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
             }
             else if (a->conjugation && a != a->conjugation->get_nearest_atom(b->get_location())) continue;
             else if (b->conjugation && b != b->conjugation->get_nearest_atom(a->get_location())) continue;
+
+            if (a->conjugation && a->conjugation->spent) continue;
+            if (b->conjugation && b->conjugation->spent) continue;
         }
 
         if (!forces[i]->distance) continue;
@@ -1128,6 +1134,8 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
             if (forces[i]->type == ionic && a->get_charge() && b->get_charge())
             {
                 partial *= achg * -bchg;
+                a->conjugation->spent = true;
+                b->conjugation->spent = true;
             }
 
             if (forces[i]->type == hbond && fabs(apol) && fabs(bpol)) partial *= fabs(apol) * fabs(bpol);

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -1134,8 +1134,8 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
             if (forces[i]->type == ionic && a->get_charge() && b->get_charge())
             {
                 partial *= achg * -bchg;
-                a->conjugation->spent = true;
-                b->conjugation->spent = true;
+                if (a->conjugation) a->conjugation->spent = true;
+                if (b->conjugation) b->conjugation->spent = true;
             }
 
             if (forces[i]->type == hbond && fabs(apol) && fabs(bpol)) partial *= fabs(apol) * fabs(bpol);

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -817,6 +817,17 @@ int Molecule::has_hbond_acceptors()
     return result;
 }
 
+void Molecule::reset_spent_conjugations()
+{
+    if (!atoms) return;
+
+    int i;
+    for (i=0; atoms[i]; i++)
+    {
+        if (atoms[i]->conjugation) atoms[i]->conjugation->spent = false;
+    }
+}
+
 int Molecule::from_sdf(char const* sdf_dat)
 {
     if (!sdf_dat) return 0;
@@ -3149,9 +3160,12 @@ float Molecule::cfmol_multibind(Molecule* a, Molecule** nearby)
     float result = -a->total_eclipses();
     if (a->is_residue()) result += reinterpret_cast<AminoAcid*>(a)->initial_eclipses;
 
+    a->reset_spent_conjugations();
+
     int j;
     for (j=0; nearby[j]; j++)
     {
+        nearby[j]->reset_spent_conjugations();
         float f = a->intermol_bind_for_multimol_dock(nearby[j], false);
         result += f;
     }
@@ -3159,6 +3173,7 @@ float Molecule::cfmol_multibind(Molecule* a, Molecule** nearby)
     {
         for (j=0; a->mclashables[j]; j++)
         {
+            a->mclashables[j]->reset_spent_conjugations();
             float f = a->intermol_bind_for_multimol_dock(a->mclashables[j], false);
             result += f;
         }

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -149,6 +149,7 @@ public:
     void clear_atom_binding_energies();
     int has_hbond_donors();
     int has_hbond_acceptors();                    // N+ is not an h-bond acceptor.
+    void reset_spent_conjugations();
 
     // Bond functions.
     Bond** get_rotatable_bonds();

--- a/src/classes/scoring.cpp
+++ b/src/classes/scoring.cpp
@@ -204,11 +204,13 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
         res_clash_dir[i] = SCoord(0,0,0);
     }
 
+    ligand->reset_spent_conjugations();
     for (i=0; i<sphres; i++)
     {
         if (!reaches_spheroid[i]) continue;
         if (!protein->aa_ptr_in_range(reaches_spheroid[i])) continue;
         reaches_spheroid[i]->clear_atom_binding_energies();
+        reaches_spheroid[i]->reset_spent_conjugations();
         int resno = reaches_spheroid[i]->get_residue_no();
 
         float lb = ligand->get_intermol_binding(reaches_spheroid[i], false);
@@ -294,6 +296,7 @@ DockResult::DockResult(Protein* protein, Molecule* ligand, Point size, int* addl
             if (!mtlcoords[i].mtl) continue;
             Molecule lm("MTL");
             lm.add_existing_atom(mtlcoords[i].mtl);
+            lm.reset_spent_conjugations();
             float f = ligand->get_intermol_binding(&lm);
             btot += f;
         }


### PR DESCRIPTION
Previously, an ionic bond between conjugated ions would be counted multiple times, once for each pair of atoms that could interact. For example, the bond between a carboxylate ion and a guanidinium group could include the interactions between each oxygen atom and each hydrogen atom, each oxygen and each nitrogen, etc. The result was ionic bonds routinely being calculated as being several hundred kJ/mol in strength, when a typical ionic bond under ideal conditions should be at most around 60 kJ/mol.

This PR offers a solution by keeping track of each conjugated system and, if an ionic bond is measured between it and any oppositely charged ion, marking the conjugation as "spent" until the next time intermolecular forces are measured. The OR51E2 propionate test elucidates the change, with hydrogen bonding strength exceeding ionic bond strength, as it should, compared to the previous result in which the reverse was the case.

```
PDB file: pdbs/OR51/OR51E2.bound.pdb
Ligand: sdf/propionic_acid.sdf

Static dock - no path nodes.

Pose: 1
Node: 0
# Binding energies:
BENERG:
Met100: -0.00734661
His104: -0.373798
Phe155: -0.221667
Leu158: -0.447505
Val179: -0.104339
His180: 0.73207
Gln181: -1.4599
Asp182: 7.06171
Met184: -0.347093
Lys185: 1.44876
Asn194: 0.440584
Val195: 0.70997
Tyr197: -0.0919579
Gly198: 1.49678
Leu199: -0.477329
Ala201: -0.267518
Ile202: -0.945552
Leu203: -0.00468181
Met206: -0.0163764
Ser258: -17.3818
His261: -0.11028
Arg262: -41.5602

Total ionic: -29.4012
Total H-bond: -40.2665
Total pi stack: -0.173314
Total polar-pi and cation-pi: -0
Total metal coordination: -0
Total van der Waals: -1.70663
Total: -47.8293
```

Still, this PR is not a perfect solution, as it operates on a first-come first-serve basis, i.e. the interaction between whichever pair of atoms from the ions is first to be processed is the only ionic interaction to be calculated for either ion. Suppose a guanidinium group were placed between two carboxylate ions, only one side will register an ionic interaction. The ideal would be to split up the charge between all interacting atoms of all interacting molecules, weighted by their distances and anisotropies. As that would be a large coding project, with the potential to result in a performance hit, and since hydrogen bonds can still be figured between oppositely charged organic ions, this simpler solution is adequate and preferable.