### PR TITLE
Output options

### DIFF
--- a/data/odorant.json
+++ b/data/odorant.json
@@ -1238,11 +1238,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "buttermilk",
-                "buttery",
-                "cheesy",
-                "creamy",
-                "dairy"
+                "creamy buttery buttermilk dairy cheesy fatty waxy sweaty green"
             ]
         },
         "activity":
@@ -1965,15 +1961,16 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "acacia",
-                "anisic",
-                "balsamic",
-                "cherry",
-                "hawthorn",
-                "maraschino_cherry",
-                "powdery",
                 "sweet",
-                "vanilla"
+                "hawthorn",
+                "anisic",
+                "powdery",
+                "balsamic",
+                "acacia",
+                "vanilla",
+                "maraschino_cherry",
+                "fruity",
+                "cherry"
             ]
         },
         "activity":
@@ -3207,9 +3204,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "alliaceous",
-                "garlic",
-                "onion"
+                "alliaceous garlic onion sulfurous savory"
             ]
         },
         "activity":
@@ -3307,9 +3302,9 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "horseradish",
-                "mustard",
                 "pungent",
+                "mustard",
+                "horseradish",
                 "wasabi"
             ]
         },
@@ -3538,10 +3533,10 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "banana",
                 "ethereal",
+                "solvent",
                 "fruity",
-                "solvent"
+                "banana"
             ]
         },
         "activity":
@@ -5419,8 +5414,8 @@
             "http:\/\/www.thegoodscentscompany.com":
             [
                 "earthy",
-                "green",
-                "mushroom"
+                "mushroom",
+                "green"
             ]
         },
         "oid": "208126b0b0342d3260d62543fdfa84f9"
@@ -7392,16 +7387,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "amber",
-                "ambergris",
-                "cedar",
-                "dry",
-                "green",
-                "musk",
-                "paper",
-                "pine",
-                "seedy",
-                "woody"
+                "dry amber ambergris paper musk woody cedar pine green seedy"
             ]
         },
         "activity":
@@ -7462,15 +7448,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "alliaceous",
-                "charred",
-                "cooked",
-                "garlic",
-                "grilled",
-                "meaty",
-                "onion",
-                "roasted",
-                "sulfurous"
+                "alliaceous sulfurous garlic onion roasted cooked_onion grilled charred meaty"
             ]
         },
         "activity":
@@ -20368,7 +20346,11 @@
             "http:\/\/www.thegoodscentscompany.com":
             [
                 "earthy",
-                "roasted"
+                "nutty",
+                "floral",
+                "fruity",
+                "smoky",
+                "musty"
             ]
         },
         "oid": "88e574d1d8cfa60da4e30780d6c11fb2"
@@ -20681,15 +20663,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "beefy",
-                "coffee",
-                "cooked",
-                "eggnog",
-                "fatty",
-                "garlic",
-                "onion",
-                "roasted",
-                "sulfurous"
+                "sulfurous garlic onion eggnog coffee fatty beefy roasted cooked"
             ]
         },
         "activity":
@@ -22571,8 +22545,8 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "apricot",
-                "sweet"
+                "sweet",
+                "apricot"
             ]
         },
         "activity":
@@ -22595,14 +22569,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "apple",
-                "candy",
-                "fruity",
-                "green",
-                "pineapple",
-                "sweet",
-                "tropical",
-                "waxy"
+                "sweet pineapple tropical fruity candy waxy apple green"
             ]
         },
         "activity":
@@ -23696,12 +23663,12 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
+                "sweet",
                 "buttery",
                 "creamy",
                 "dairy",
-                "fatty",
                 "milky",
-                "sweet"
+                "fatty"
             ]
         },
         "oid": "a3cf80cc781a4b75f7a493ae3fd7f346"
@@ -26882,8 +26849,8 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "balsamic",
                 "floral",
+                "balsamic",
                 "strawberry"
             ]
         },
@@ -27582,14 +27549,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "apple",
-                "estery",
-                "fatty",
-                "fruity",
-                "green",
-                "pear",
-                "pineapple",
-                "sweet"
+                "sweet green fruity estery pineapple apple pear fatty waxy cognac melon"
             ]
         },
         "activity":
@@ -28280,11 +28240,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "beany",
-                "chocolate",
-                "earthy",
-                "green_pea",
-                "nutty"
+                "green_pea earthy beany chocolate nutty"
             ]
         },
         "activity":
@@ -28594,10 +28550,10 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "brandy",
                 "fruity",
                 "plum",
-                "rummy"
+                "rummy",
+                "brandy"
             ]
         },
         "activity":
@@ -29487,14 +29443,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "balsamic",
-                "cherry",
-                "fruity",
-                "plum",
-                "powdery",
-                "sweet",
-                "tonka",
-                "vanilla"
+                "sweet powdery balsamic vanilla fruity plum cherry tonka creamy spicy coumarinic licorice"
             ]
         },
         "activity":
@@ -29789,14 +29738,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "apple",
-                "balsamic",
-                "banana",
-                "floral",
-                "fruity",
-                "jammy",
-                "jasmine",
-                "sweet"
+                "sweet fruity floral banana jasmin balsamic apple jammy"
             ]
         },
         "activity":
@@ -29852,14 +29794,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "buttery",
-                "caramellic",
-                "cheesy",
-                "creamy",
-                "nutty",
-                "pungent",
-                "sweet",
-                "toasted"
+                "pungent sweet buttery creamy caramellic nutty cheesy toasted"
             ]
         },
         "oid": "d29864c976c6cfe62702be8c00a6a64b"
@@ -30354,10 +30289,10 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "grain",
-                "malty",
                 "popcorn",
-                "toasted"
+                "toasted",
+                "grain",
+                "malty"                
             ]
         },
         "oid": "d5ca075c633a3f8067608fae49d2d7e8"
@@ -33812,12 +33747,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "balsamic",
-                "fermented",
-                "fusel",
-                "oily",
-                "sweet",
-                "whiskey"
+                "fusel oily sweet balsamic whiskey banana"
             ]
         },
         "activity":
@@ -34026,12 +33956,13 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "aldehydic",
+                "pungent",
                 "ethereal",
-                "fresh",
+                "aldehydic",
                 "fruity",
+                "fresh",
                 "musty",
-                "pungent"
+                "green"
             ]
         },
         "oid": "ee4712455d4830701a6b998d87a6d9bb"
@@ -35414,13 +35345,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "banana",
-                "cognac",
-                "fruity",
-                "fusel",
-                "pineapple",
-                "sweet",
-                "waxy"
+                "sweet pineapple fruity waxy banana fusel cognac ripe fermented"
             ]
         },
         "activity":
@@ -36094,11 +36019,10 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "alcoholic",
-                "cucumber",
+                "solvent",
                 "ethereal",
-                "fruity",
-                "sweet"
+                "apple",
+                "pear"
             ]
         },
         "oid": "fa0d6b210c7526b5976c0d59860b1cf6"
@@ -36565,6 +36489,7 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
+                "acidic",
                 "sharp",
                 "vinegar"
             ]
@@ -36579,8 +36504,8 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "fruity",
                 "honey",
+                "fruity",
                 "rummy"
             ]
         },
@@ -36755,8 +36680,9 @@
         {
             "http:\/\/www.thegoodscentscompany.com":
             [
-                "acrid",
                 "sharp",
+                "pungent",
+                "sour",
                 "vinegar"
             ]
         },

--- a/data/odorutils.php
+++ b/data/odorutils.php
@@ -16,6 +16,11 @@ foreach ($odors as $oid => $odor)
 	{
 		if (@$refs[$url]["hidden"]) unset($odors[$oid]["activity"][$url]);
 	}
+
+	if (!empty($odor["aroma"])) foreach ($odor["aroma"] as $url => $aroma)
+	{
+		if (count($aroma) == 1 && false!==strpos($aroma[0], " ")) $odors[$oid]['aroma'][$url] = explode(" ", $aroma[0]);
+	}
 }
 
 function trim_prefixes($what)

--- a/primarydock.config
+++ b/primarydock.config
@@ -223,6 +223,7 @@ OUT output/%p_%l.dock
 # OUTLPS 0          # If nonzero, the ligand's polar satisfaction will be included.
 # OUTPROX 0         # If nonzero, the ligand's proximity to the pocket center will be included.
 # OUTPCLSH 0        # If nonzero, the protein's internal clashes will be included.
+# OUTMC 0           # If nonzero, the per-residue missed-connection attractions will be included.
 # OUTVDWR 0         # If nonzero, the per-residue van der Waals repulsions will be included.
 # OUTPDBL 1         # If nonzero, the ligand conformer will be included in the PDB data.
 # OUTPDBR 1         # If nonzero, the binding residues, including any flexions if FLEX is enabled,

--- a/primarydock.config
+++ b/primarydock.config
@@ -212,4 +212,19 @@ OUT output/%p_%l.dock
 # entire result including the protein backbone:
 # APPENDPROT
 
+# Optional output switches and their defaults.
+# PERRES 1          # If nonzero, the per-residue binding energies will be included.
+# PERBTYP 1         # If nonzero, the per-interation-type energies will be included.
+# ELIMITEM 0.01     # The magnitude limit for itemized (i.e. per-residue and per-type) energies.
+                    # Only energies greater than ELIMITEM or less than -ELIMITEM will be included.
+# LIGINTE 1         # If nonzero, the ligand's internal energy will be included.
+# OUTBBP 0          # If nonzero, the best-binding pair assignments will be included.
+                    # OUTBBP is only valid if SEARCH BB.
+# OUTLPS 0          # If nonzero, the ligand's polar satisfaction will be included.
+# OUTPROX 0         # If nonzero, the ligand's proximity to the pocket center will be included.
+# OUTPCLSH 0        # If nonzero, the protein's internal clashes will be included.
+# OUTVDWR 0         # If nonzero, the per-residue van der Waals repulsions will be included.
+# OUTPDBL 1         # If nonzero, the ligand conformer will be included in the PDB data.
+# OUTPDBR 1         # If nonzero, the binding residues, including any flexions if FLEX is enabled,
+                    # will be included in the PDB data.
 

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -131,6 +131,7 @@
 #define lmpull 0.3
 #define lmsteps 3
 #define recapture_ejected_ligand 0
+#define summed_missed_connections 1
 
 #define amide_zwitterionic_amount 0.1
 

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -1081,13 +1081,18 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
 
                 SCoord mc = bloc.subtract(aloc);
                 mc.r = r - forces[i]->distance; // fabs((r1 - 1) * (1.0 - (partial / forces[i]->kJ_mol)) / (r1*r1));
-                // missed_connection = missed_connection.add(mc);
+
+                #if summed_missed_connections
+                missed_connection = missed_connection.add(mc);
+                mc_bpotential += forces[i]->kJ_mol;
+                #else
                 if ((mc.r < fabs(missed_connection.r) && forces[i]->kJ_mol >= mc_bpotential)
                     || forces[i]->kJ_mol > mc_bpotential)
                 {
                     missed_connection = mc;
                     mc_bpotential = forces[i]->kJ_mol;
                 }
+                #endif
             }
             else
             {

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -14,6 +14,7 @@ float total_binding_by_type[_INTER_TYPES_LIMIT];
 float minimum_searching_aniso = 0;
 InteratomicForce* lif = nullptr;
 SCoord missed_connection(0,0,0);
+float mc_bpotential = 0;
 
 #if _peratom_audit
 std::vector<std::string> interaudit;
@@ -1080,7 +1081,13 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
 
                 SCoord mc = bloc.subtract(aloc);
                 mc.r = r - forces[i]->distance; // fabs((r1 - 1) * (1.0 - (partial / forces[i]->kJ_mol)) / (r1*r1));
-                missed_connection = missed_connection.add(mc);
+                // missed_connection = missed_connection.add(mc);
+                if ((mc.r < fabs(missed_connection.r) && forces[i]->kJ_mol >= mc_bpotential)
+                    || forces[i]->kJ_mol > mc_bpotential)
+                {
+                    missed_connection = mc;
+                    mc_bpotential = forces[i]->kJ_mol;
+                }
             }
             else
             {

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -1079,7 +1079,7 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
                 partial = aniso * forces[i]->kJ_mol / rdecayed;
 
                 SCoord mc = bloc.subtract(aloc);
-                mc.r = fabs((r1 - 1) * (1.0 - (partial / forces[i]->kJ_mol)) / (r1*r1));
+                mc.r = r - forces[i]->distance; // fabs((r1 - 1) * (1.0 - (partial / forces[i]->kJ_mol)) / (r1*r1));
                 missed_connection = missed_connection.add(mc);
             }
             else

--- a/src/classes/intera.h
+++ b/src/classes/intera.h
@@ -74,6 +74,7 @@ std::ostream& operator<<(std::ostream& os, const InteratomicForce& f);
 extern float total_binding_by_type[_INTER_TYPES_LIMIT];
 extern float minimum_searching_aniso;                       // Should be a small positive number for searching, and zero for scoring.
 extern SCoord missed_connection;
+extern float mc_bpotential;
 
 #if active_persistence
 extern int active_persistence_resno[active_persistence_limit];

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2800,7 +2800,8 @@ float Molecule::get_intermol_binding(Molecule** ligands, bool subtract_clashes)
                             !ligands[l]->shielded(atoms[i], ligands[l]->atoms[j])
                        )
                     {
-                        missed_connection.r = 0;
+                        missed_connection.r = -Avogadro;
+                        mc_bpotential = 0;
                         // cout << ligands[l]->atoms[j]->get_location().subtract(atoms[i]->get_location()) << ": ";
                         float abind = InteratomicForce::total_binding(atoms[i], ligands[l]->atoms[j]);
                         #if _dbg_internal_energy
@@ -2838,11 +2839,15 @@ float Molecule::get_intermol_binding(Molecule** ligands, bool subtract_clashes)
                                 lmz += lmpush * sgn(ptd.z);
                             }
                         }
-                        Point mc = missed_connection;
-                        // cout << mc << endl;
-                        lmx += lmpull * mc.x;
-                        lmy += lmpull * mc.y;
-                        lmz += lmpull * mc.z;
+
+                        if (missed_connection.r > 0)
+                        {
+                            Point mc = missed_connection;
+                            // cout << mc << endl;
+                            lmx += lmpull * mc.x * mc_bpotential / missed_connection.r / missed_connection.r;
+                            lmy += lmpull * mc.y * mc_bpotential / missed_connection.r / missed_connection.r;
+                            lmz += lmpull * mc.z * mc_bpotential / missed_connection.r / missed_connection.r;
+                        }
                     }
                     else lastshielded += InteratomicForce::total_binding(atoms[i], ligands[l]->atoms[j]);
                 }

--- a/src/classes/scoring.h
+++ b/src/classes/scoring.h
@@ -29,6 +29,7 @@ class DockResult
     Atom* worst_clash_2 = nullptr;
     float* residue_clash = nullptr;
     SCoord* res_clash_dir = nullptr;
+    float* missed_connections = 0;
     const char** m_atom1_name = nullptr;
     const char** m_atom2_name = nullptr;
     std::string pdbdat;
@@ -56,6 +57,7 @@ class DockResult
     bool out_lig_pol_sat = false;
     bool out_prox = false;
     bool out_pro_clash = false;
+    bool out_mc = false;
     bool out_vdw_repuls = false;
 };
 

--- a/src/classes/scoring.h
+++ b/src/classes/scoring.h
@@ -48,6 +48,15 @@ class DockResult
     bool display_clash_atom1 = false;
     bool display_clash_atom2 = false;
     float energy_mult = 1;
+
+    bool out_per_res_e = true;
+    bool out_per_btyp_e = true;
+    float out_itemized_e_cutoff = 0.01;
+    bool out_lig_int_e = true;
+    bool out_lig_pol_sat = false;
+    bool out_prox = false;
+    bool out_pro_clash = false;
+    bool out_vdw_repuls = false;
 };
 
 extern float init_total_binding_by_type[_INTER_TYPES_LIMIT];

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -1096,57 +1096,57 @@ int interpret_config_line(char** words)
     }
     else if (!strcmp(words[0], "PERRES"))
     {
-        bool out_per_res_e = atoi(words[1]);
+        out_per_res_e = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "PERBTYP"))
     {
-        bool out_per_btyp_e = atoi(words[1]);
+        out_per_btyp_e = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "ELIMITEM"))
     {
-        float out_itemized_e_cutoff = atoi(words[1]);
+        out_itemized_e_cutoff = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "LIGINTE"))
     {
-        bool out_lig_int_e = atoi(words[1]);
+        out_lig_int_e = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTBBP"))
     {
-        bool out_bb_pairs = atoi(words[1]);
+        out_bb_pairs = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTLPS"))
     {
-        bool out_lig_pol_sat = atoi(words[1]);
+        out_lig_pol_sat = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTPROX"))
     {
-        bool out_prox = atoi(words[1]);
+        out_prox = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTPCLSH"))
     {
-        bool out_pro_clash = atoi(words[1]);
+        out_pro_clash = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTVDWR"))
     {
-        bool out_vdw_repuls = atoi(words[1]);
+        out_vdw_repuls = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTPDBL"))
     {
-        bool out_pdbdat_lig = atoi(words[1]);
+        out_pdbdat_lig = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTPDBR"))
     {
-        bool out_pdbdat_res = atoi(words[1]);
+        out_pdbdat_res = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "POSE"))
@@ -3173,6 +3173,7 @@ _try_again:
                 if (debug) *debug << "Prepared flex PDBs." << endl;
                 #endif
             }
+            else if (!out_pdbdat_lig) pdbdat << " ";
 
             if (mtlcoords.size() && out_pdbdat_lig)
             {

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -99,8 +99,7 @@ bool out_prox = false;
 bool out_pro_clash = false;
 bool out_vdw_repuls = false;
 bool out_pdbdat_lig = true;
-bool out_pdbdat_res = true;         // Valid only if FLEX is enabled.
-bool out_pdbdat_res_specified = false;
+bool out_pdbdat_res = true;
 
 Protein* protein;
 Protein* ptemplt;
@@ -1148,7 +1147,6 @@ int interpret_config_line(char** words)
     else if (!strcmp(words[0], "OUTPDBR"))
     {
         bool out_pdbdat_res = atoi(words[1]);
-        out_pdbdat_res_specified = true;
         return 1;
     }
     else if (!strcmp(words[0], "POSE"))
@@ -1893,11 +1891,6 @@ int main(int argc, char** argv)
             argv[i] -= 2;
             i += j;
         }
-    }
-
-    if (out_pdbdat_res_specified && out_pdbdat_res && !flex)
-    {
-        cout << "Warning: OUTPDBR is only valid when flexion is enabled." << endl;
     }
 
     if (out_bb_pairs && !use_bestbind_algorithm)
@@ -3148,7 +3141,7 @@ _try_again:
 
             sphres = protein->get_residues_can_clash_ligand(reaches_spheroid[nodeno], ligand, pocketcen, size, addl_resno);
 
-            if (flex && out_pdbdat_res)
+            if (out_pdbdat_res)
             {
                 int en = protein->get_end_resno();
                 int resno;
@@ -3156,7 +3149,7 @@ _try_again:
                 {
                     AminoAcid* laa = protein->get_residue(resno);
                     if (!laa) continue;
-                    if (!laa->been_flexed)
+                    if (!flex || !laa->been_flexed)
                     {
                         if (laa->distance_to(ligand) > 5) continue;
                         for (k=0; reaches_spheroid[nodeno][k]; k++)

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -97,6 +97,7 @@ bool out_bb_pairs = false;
 bool out_lig_pol_sat = false;
 bool out_prox = false;
 bool out_pro_clash = false;
+bool out_mc = false;
 bool out_vdw_repuls = false;
 bool out_pdbdat_lig = true;
 bool out_pdbdat_res = true;
@@ -1132,6 +1133,11 @@ int interpret_config_line(char** words)
     else if (!strcmp(words[0], "OUTPCLSH"))
     {
         out_pro_clash = atoi(words[1]);
+        return 1;
+    }
+    else if (!strcmp(words[0], "OUTMC"))
+    {
+        out_mc = atoi(words[1]);
         return 1;
     }
     else if (!strcmp(words[0], "OUTVDWR"))
@@ -3040,6 +3046,7 @@ _try_again:
             dr[drcount][nodeno].out_lig_pol_sat = out_lig_pol_sat;
             dr[drcount][nodeno].out_prox = out_prox;
             dr[drcount][nodeno].out_pro_clash = out_pro_clash;
+            dr[drcount][nodeno].out_mc = out_mc;
             dr[drcount][nodeno].out_vdw_repuls = out_vdw_repuls;
             float btot = dr[drcount][nodeno].kJmol;
             float pstot = dr[drcount][nodeno].polsat;

--- a/www/assets/style.css
+++ b/www/assets/style.css
@@ -303,6 +303,7 @@ table.rcplist tr:nth-of-type(odd), table.liglist tr:nth-of-type(odd)
 {
     float: left;
     margin-right: 15px;
+    width: 97%;
 }
 
 .rcptile

--- a/www/odorants.php
+++ b/www/odorants.php
@@ -18,22 +18,66 @@ if (!file_exists($pqcorr = "../data/receptor_pq.json"))
     echo " This calculation takes a few moments.<br><br>";
 }
 
+echo "<p><a name=\"top\"></a>";
+for ($l = 1; $l < 28; $l++)
+{
+    if ($l <= 26) echo "<a href=\"#letter_$l\">".chr(64+$l)."</a> ";
+    else echo "<a href=\"#letter_123\">#</a>";
+}
+echo "</p>";
+
 echo "<div class=\"odorlist\">\n";
 for ($l = 1; $l < 28; $l++)
 {
-    if ($l <= 26) echo "<h2>".chr(64+$l)."</h2>";
-    else echo "<h2>Others</h2>";
+    if ($l <= 26) echo "<a name=\"letter_$l\"><h2>".chr(64+$l)."</h2></a>";
+    else echo "<a name=\"letter_123\"><h2>Others</h2></a>";
+
+    $tl = [];
     foreach (array_keys($odors) as $oid)
     {
         $odor = $odors[$oid];
         $C = strtoupper(substr(trim_prefixes($odor['full_name']), 0, 1));
         if ($l <= 26 && $C != chr(64+$l)) continue;
         if ($l > 26 && ($C >= 'A' && $C <= 'Z')) continue;
-        $fnu = urlencode($odor['full_name']);
-        echo "<a href=\"odorant.php?o=$oid\">".hellenicize($odor['full_name'])."</a> ";
-        // echo trim_prefixes($odor['full_name']);
-        echo "<br>\n";
+
+        if (@$_REQUEST['gsac'])
+        {
+            $notes = @$odor['aroma']["http://www.thegoodscentscompany.com"];
+            if (is_array($notes) && count($notes))
+            {
+                if (count($notes) < 2) continue;
+                natsort($notes);
+                if (implode(" ", $notes) != implode(" ", $odor['aroma']["http://www.thegoodscentscompany.com"])) continue;
+            }
+            else continue;
+        }
+
+        $tl[$oid] = hellenicize($odor['full_name']);
     }
+
+    $cols = 5;
+    $pcnt = intval(100/$cols);
+    $pcol = ceil(count($tl)/$cols);
+
+    echo "<div style=\"display: flex; width: 100%;\">\n";
+    echo "<div style=\"width: $pcnt%;\">\n";
+    $o = 0;
+    $col = 1;
+    foreach ($tl as $oid => $name)
+    {
+        $fnu = urlencode($odor['full_name']);
+        echo "<a href=\"odorant.php?o=$oid\">$name</a> ";
+        echo "<br>\n";
+        $o++;
+        if ($o >= $pcol && $col < $cols)
+        {
+            echo "</div><div style=\"width: $pcnt%;\">\n";
+            $o = 0;
+            $col++;
+        }
+    }
+    echo "</div>\n</div>\n";
+    echo "<p><a href=\"#top\">(back to top)</a></p>";
     echo "<hr>";
 }
 echo "</div>\n";


### PR DESCRIPTION
Cleans up the output of the PrimaryDock application by allowing the user to turn several switches on and off for things like per-residue energy, van der Waals repulsions, best-binding pair assignments, etc.

Also adds a new output section, off by default, for "missed connections", i.e. potential binding contacts that were not met due to too much distance between atoms.