### PR TITLE
Bond reciprocity

### DIFF
--- a/src/amino_test.cpp
+++ b/src/amino_test.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
             {
                 for (j=0; b[j]; j++)
                 {
-                    cout << b[j]->atom1->name << " - " << b[j]->atom2->name << endl;
+                    cout << b[j]->get_atom1()->name << " - " << b[j]->get_atom2()->name << endl;
                 }
             }
             cout << endl;
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
                 {
                     Atom* baa[bb[i]->count_moves_with_atom2()+1];
                     bb[i]->fetch_moves_with_atom2(baa);
-                    cout << bb[i]->atom1->name << "-" << bb[i]->atom2->name << " can rotate, bringing ";
+                    cout << bb[i]->get_atom1()->name << "-" << bb[i]->get_atom2()->name << " can rotate, bringing ";
 
                     for (j=0; baa[j]; j++)
                     {

--- a/src/amino_test.cpp
+++ b/src/amino_test.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
             {
                 for (j=0; b[j]; j++)
                 {
-                    cout << b[j]->atom->name << " - " << b[j]->btom->name << endl;
+                    cout << b[j]->atom1->name << " - " << b[j]->atom2->name << endl;
                 }
             }
             cout << endl;
@@ -83,9 +83,9 @@ int main(int argc, char** argv)
             {
                 for (i=0; bb[i]; i++)
                 {
-                    Atom* baa[bb[i]->count_moves_with_btom()+1];
-                    bb[i]->fetch_moves_with_btom(baa);
-                    cout << bb[i]->atom->name << "-" << bb[i]->btom->name << " can rotate, bringing ";
+                    Atom* baa[bb[i]->count_moves_with_atom2()+1];
+                    bb[i]->fetch_moves_with_atom2(baa);
+                    cout << bb[i]->atom1->name << "-" << bb[i]->atom2->name << " can rotate, bringing ";
 
                     for (j=0; baa[j]; j++)
                     {

--- a/src/aniso_test.cpp
+++ b/src/aniso_test.cpp
@@ -128,14 +128,14 @@ int main(int argc, char** argv)
     {
         for (i=0; bb[i]; i++)
         {
-            if (!bb[i]->btom) break;
-            Point pt = bb[i]->btom->get_location();
+            if (!bb[i]->atom2) break;
+            Point pt = bb[i]->atom2->get_location();
             pt = pt.subtract(aloc);
             pt.scale(1);
             pt = pt.add(aloc);
             pt.weight = 1;
             bblocs[i] = pt;
-            // cout << bb[i]->btom->name << endl;
+            // cout << bb[i]->atom2->name << endl;
         }
 
         // cout << i << " points for average." << endl;

--- a/src/aniso_test.cpp
+++ b/src/aniso_test.cpp
@@ -128,14 +128,14 @@ int main(int argc, char** argv)
     {
         for (i=0; bb[i]; i++)
         {
-            if (!bb[i]->atom2) break;
-            Point pt = bb[i]->atom2->get_location();
+            if (!bb[i]->get_atom2()) break;
+            Point pt = bb[i]->get_atom2()->get_location();
             pt = pt.subtract(aloc);
             pt.scale(1);
             pt = pt.add(aloc);
             pt.weight = 1;
             bblocs[i] = pt;
-            // cout << bb[i]->atom2->name << endl;
+            // cout << bb[i]->get_atom2()->name << endl;
         }
 
         // cout << i << " points for average." << endl;

--- a/src/classes/aminoacid.cpp
+++ b/src/classes/aminoacid.cpp
@@ -153,14 +153,14 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
             strcpy(atoms[i]->aa3let, aa_defs[idx]._3let);
             atom_isheavy[i] = (atoms[i]->get_Z() != 1);
 
-            // If the atom is hydrogen, its Greek will be the same as its bond[0]->btom. Otherwise, it will be one more.
+            // If the atom is hydrogen, its Greek will be the same as its bond[0]->atom2. Otherwise, it will be one more.
             Bond* b0 = atoms[i]->get_bond_by_idx(0);
-            if (!b0 || !b0->btom)
+            if (!b0 || !b0->atom2)
             {
                 cout << "Error in definition for " << aa_defs[idx].name << "." << endl;
                 throw 0xbadac1d;
             }
-            j = atom_idx_from_ptr(b0->btom);
+            j = atom_idx_from_ptr(b0->atom2);
             if (j < 0)
             {
                 cout << "Error in definition for " << aa_defs[idx].name << "." << endl;
@@ -182,12 +182,12 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                     atoms[i]->fetch_bonds(ab);
                     for (j=0; ab[j]; j++)
                     {
-                        if (ab[j]->btom
+                        if (ab[j]->atom2
                                 &&
-                                ab[j]->btom->get_family() == TETREL
+                                ab[j]->atom2->get_family() == TETREL
                            )
                         {
-                            O = ab[j]->btom->is_bonded_to(CHALCOGEN, 2);
+                            O = ab[j]->atom2->is_bonded_to(CHALCOGEN, 2);
                             if (O)
                             {
                                 CA = atoms[i];
@@ -201,7 +201,7 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                                     numgrk[atom_Greek[k]]++;
                                 }
 
-                                C = ab[j]->btom;
+                                C = ab[j]->atom2;
                                 C->name = new char[5];
                                 strcpy(C->name, "C");
                                 C->is_backbone = true;
@@ -227,11 +227,11 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                                     int n;
                                     for (n=0; ab[n]; n++)
                                     {
-                                        if (ab[n]->btom && ab[n]->btom->get_Z() == 1)
+                                        if (ab[n]->atom2 && ab[n]->atom2->get_Z() == 1)
                                         {
                                             if (!l)
                                             {
-                                                HN = ab[n]->btom;
+                                                HN = ab[n]->atom2;
                                                 HN->name = new char[5];
                                                 strcpy(HN->name, "HN");
                                                 HN->is_backbone = true;
@@ -273,9 +273,9 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                 for (j=0; j<ag; j++)
                 {
                     if (!ab[j]) continue;
-                    if (ab[j]->btom)
+                    if (ab[j]->atom2)
                     {
-                        k = atom_idx_from_ptr(ab[j]->btom);
+                        k = atom_idx_from_ptr(ab[j]->atom2);
                         if (k >= 0 && !atom_Greek[k])
                         {
                             atom_Greek[k] = atom_Greek[i]+1;
@@ -298,10 +298,10 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                     for (j=0; j<ag; j++)
                     {
                          if (!ab[j]) continue;
-                        if (ab[j]->btom)
+                        if (ab[j]->atom2)
                         {
-                            // cout << atoms[i]->name << " is bonded to " << ab[j]->btom->name << name << endl;
-                            k = atom_idx_from_ptr(ab[j]->btom);
+                            // cout << atoms[i]->name << " is bonded to " << ab[j]->atom2->name << name << endl;
+                            k = atom_idx_from_ptr(ab[j]->atom2);
                             // cout << "Greek is " << atom_Greek[i] << " vs. bonded Greek " << atom_Greek[k] << endl;
                             if (atom_isheavy[k] && atom_Greek[k] > 0)
                             {
@@ -567,17 +567,17 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
             for (j=0; j<bg; j++)
             {
                 if (!bb[j]) break;
-                if (bb[j]->btom && bb[j]->btom < bb[j]->atom)
+                if (bb[j]->atom2 && bb[j]->atom2 < bb[j]->atom1)
                 {
                     aabd[n] = new AABondDef();
-                    strcpy(aabd[n]->aname, bb[j]->atom->name);
-                    strcpy(aabd[n]->bname, bb[j]->btom->name);
-                    aabd[n]->Za = bb[j]->atom->get_Z();
-                    aabd[n]->Zb = bb[j]->btom->get_Z();
+                    strcpy(aabd[n]->aname, bb[j]->atom1->name);
+                    strcpy(aabd[n]->bname, bb[j]->atom2->name);
+                    aabd[n]->Za = bb[j]->atom1->get_Z();
+                    aabd[n]->Zb = bb[j]->atom2->get_Z();
                     aabd[n]->cardinality = bb[j]->cardinality;
-                    aabd[n]->acharge = bb[j]->atom->get_charge();
+                    aabd[n]->acharge = bb[j]->atom1->get_charge();
 
-                    if (!strcmp(bb[j]->atom->name, "OH") && !strcmp(bb[j]->btom->name, "CZ"))
+                    if (!strcmp(bb[j]->atom1->name, "OH") && !strcmp(bb[j]->atom2->name, "CZ"))
                     {
                         aabd[n]->can_rotate = false;
                         aabd[n]->can_flip = true;
@@ -586,49 +586,49 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                     aabd[n]->can_rotate =
                         (	aabd[n]->cardinality <= 1.1
                             &&
-                            (	!bb[j]->atom->is_pi() || !bb[j]->btom->is_pi()	)
+                            (	!bb[j]->atom1->is_pi() || !bb[j]->atom2->is_pi()	)
                             &&
-                            (	!bb[j]->atom->is_pi()
+                            (	!bb[j]->atom1->is_pi()
                                 ||
-                                (   bb[j]->btom->get_family() != PNICTOGEN
+                                (   bb[j]->atom2->get_family() != PNICTOGEN
                                     &&
-                                    bb[j]->btom->get_family() != CHALCOGEN
+                                    bb[j]->atom2->get_family() != CHALCOGEN
                                 )
                                 ||
-                                bb[j]->btom->is_bonded_to_pi(TETREL, false)
+                                bb[j]->atom2->is_bonded_to_pi(TETREL, false)
                             )
                             &&
-                            (	!bb[j]->btom->is_pi()
+                            (	!bb[j]->atom2->is_pi()
                                 ||
-                                (   bb[j]->atom->get_family() != PNICTOGEN
+                                (   bb[j]->atom1->get_family() != PNICTOGEN
                                     &&
-                                    bb[j]->atom->get_family() != CHALCOGEN
+                                    bb[j]->atom1->get_family() != CHALCOGEN
                                 )
                                 ||
-                                bb[j]->atom->is_bonded_to_pi(TETREL, false)
+                                bb[j]->atom1->is_bonded_to_pi(TETREL, false)
                             )
                             &&
-                            (	bb[j]->atom->get_family() != PNICTOGEN || !bb[j]->btom->is_pi()	)
+                            (	bb[j]->atom1->get_family() != PNICTOGEN || !bb[j]->atom2->is_pi()	)
                         );
                     aabd[n]->can_flip =
                         (	aabd[n]->cardinality <= 1.1
                             &&
-                            (	!bb[j]->atom->is_pi() || !bb[j]->btom->is_pi()	)
+                            (	!bb[j]->atom1->is_pi() || !bb[j]->atom2->is_pi()	)
                             &&
                             (	(
-                                    bb[j]->atom->is_pi()
+                                    bb[j]->atom1->is_pi()
                                     &&
-                                    (   bb[j]->btom->get_family() == PNICTOGEN || bb[j]->btom->get_family() == CHALCOGEN    )
+                                    (   bb[j]->atom2->get_family() == PNICTOGEN || bb[j]->atom2->get_family() == CHALCOGEN    )
                                     &&
-                                    !bb[j]->btom->is_bonded_to_pi(TETREL, false)
+                                    !bb[j]->atom2->is_bonded_to_pi(TETREL, false)
                                 )
                                 ||
                                 (
-                                    bb[j]->btom->is_pi()
+                                    bb[j]->atom2->is_pi()
                                     &&
-                                    (   bb[j]->atom->get_family() == PNICTOGEN || bb[j]->atom->get_family() == CHALCOGEN    )
+                                    (   bb[j]->atom1->get_family() == PNICTOGEN || bb[j]->atom1->get_family() == CHALCOGEN    )
                                     &&
-                                    !bb[j]->atom->is_bonded_to_pi(TETREL, false)
+                                    !bb[j]->atom1->is_bonded_to_pi(TETREL, false)
                                 )
                             )
                         );
@@ -1225,16 +1225,16 @@ int AminoAcid::from_pdb(FILE* is, int rno)
                                 }
 
 
-                                Atom* btom = get_atom(aab->bname);
-                                if (btom)
+                                Atom* atom2 = get_atom(aab->bname);
+                                if (atom2)
                                 {
-                                    a->bond_to(btom, aab->cardinality);
+                                    a->bond_to(atom2, aab->cardinality);
                                     if (aab->cardinality == 1 && !aab->can_rotate)
                                     {
-                                        Bond* b = a->get_bond_between(btom);
+                                        Bond* b = a->get_bond_between(atom2);
                                         if (b) b->can_rotate = false;
                                         // if (b) b->can_flip = aab->can_flip;
-                                        b = btom->get_bond_between(a);
+                                        b = atom2->get_bond_between(a);
                                         if (b) b->can_rotate = false;
                                         // if (b) b->can_flip = aab->can_flip;
                                     }
@@ -1243,15 +1243,15 @@ int AminoAcid::from_pdb(FILE* is, int rno)
                             }
                             else if (!strcmp(aab->bname, a->name))
                             {
-                                Atom* btom = get_atom(aab->aname);
-                                if (btom && !btom->is_bonded_to(a))
+                                Atom* atom2 = get_atom(aab->aname);
+                                if (atom2 && !atom2->is_bonded_to(a))
                                 {
-                                    a->bond_to(btom, aab->cardinality);
+                                    a->bond_to(atom2, aab->cardinality);
                                     if (aab->cardinality == 1 && !aab->can_rotate)
                                     {
-                                        Bond* b = a->get_bond_between(btom);
+                                        Bond* b = a->get_bond_between(atom2);
                                         if (b) b->can_rotate = false;
-                                        b = btom->get_bond_between(a);
+                                        b = atom2->get_bond_between(a);
                                         if (b) b->can_rotate = false;
                                     }
                                     found_aabond = true;
@@ -1980,7 +1980,7 @@ void AminoAcid::set_conditional_basicity(Molecule** nearby_mols)
                 if (fabs(atoms[j]->get_charge()) > 0.2) continue;
 
                 Atom* a = nearby_mols[i]->get_nearest_atom(atoms[j]->get_location());
-                if (a->get_Z() == 1) a = a->get_bond_by_idx(0)->btom;
+                if (a->get_Z() == 1) a = a->get_bond_by_idx(0)->atom2;
                 if (!a) continue;
 
                 if (a->get_charge() <= -0.5 || a->is_conjugated_to_charge() <= -0.5)
@@ -1997,7 +1997,7 @@ void AminoAcid::set_conditional_basicity(Molecule** nearby_mols)
                     if (r >= cond_bas_hbond_distance_threshold) continue;
                     if (atoms[j]->get_Z() == 1)
                     {
-                        Atom* b = atoms[j]->get_bond_by_idx(0)->btom;
+                        Atom* b = atoms[j]->get_bond_by_idx(0)->atom2;
                         if (!b) continue;
                         r = atoms[j]->distance_to(b);
                         if (r >= 1.333) continue;
@@ -2341,9 +2341,9 @@ float AminoAcid::hydrophilicity() const
             for (j=0; j<atoms[i]->get_geometry(); j++)
             {
                 Bond* b = atoms[i]->get_bond_by_idx(j);
-                if (b && b->btom)
+                if (b && b->atom2)
                 {
-                    fam = b->btom->get_family();
+                    fam = b->atom2->get_family();
                     break;
                 }
             }
@@ -2473,7 +2473,7 @@ void AminoAcid::hydrogenate(bool steric_only)
         if (!bt) continue;
         bb = bt[0];
         if (!bb) continue;
-        heavy = bb->btom;
+        heavy = bb->atom2;
         if (!heavy) continue;
 
         atoms[i]->residue = heavy->residue;
@@ -2547,7 +2547,7 @@ void AminoAcid::hydrogenate(bool steric_only)
                 if (bt)
                 {
                     bb = bt[0];
-                    if (bb && bb->btom == cursor)
+                    if (bb && bb->atom2 == cursor)
                         atomtmp[l++] = atoms[i];
                 }
             }
@@ -2577,7 +2577,7 @@ void AminoAcid::hydrogenate(bool steric_only)
                                 if (bt)
                                 {
                                     bb = bt[0];
-                                    if (bb && bb->btom == cursor)
+                                    if (bb && bb->atom2 == cursor)
                                         atomtmp[l++] = atoms[k];
                                 }
                             }
@@ -2604,7 +2604,7 @@ void AminoAcid::hydrogenate(bool steric_only)
                 if (bt)
                 {
                     bb = bt[0];
-                    if (bb && bb->btom == cursor)
+                    if (bb && bb->atom2 == cursor)
                         atomtmp[l++] = atoms[i];
                 }
             }
@@ -2725,9 +2725,9 @@ Atom* AminoAcid::previous_residue_C()
     if (!n) return NULL;
     for (i=0; i<n; i++)
     {
-        Atom* btom = N->get_bond_by_idx(i)->btom;
-        if (!btom) continue;
-        if (btom->residue == N->residue-1) return btom;
+        Atom* atom2 = N->get_bond_by_idx(i)->atom2;
+        if (!atom2) continue;
+        if (atom2->residue == N->residue-1) return atom2;
     }
     return NULL;
 }
@@ -2740,9 +2740,9 @@ Atom* AminoAcid::next_residue_N()
     if (!n) return NULL;
     for (i=0; i<n; i++)
     {
-        Atom* btom = C->get_bond_by_idx(i)->btom;
-        if (!btom) continue;
-        if (btom->residue == C->residue+1) return btom;
+        Atom* atom2 = C->get_bond_by_idx(i)->atom2;
+        if (!atom2) continue;
+        if (atom2->residue == C->residue+1) return atom2;
     }
     return NULL;
 }
@@ -2763,7 +2763,7 @@ Atom* AminoAcid::HN_or_substitute()
 
         for (i=0; i<g; i++)
         {
-            if (bb[i]->btom && strcmp(bb[i]->btom->name, "CA")) return bb[i]->btom;
+            if (bb[i]->atom2 && strcmp(bb[i]->atom2->name, "CA")) return bb[i]->atom2;
         }
     }
     return retval;
@@ -2839,10 +2839,10 @@ LocRotation* AminoAcid::flatten()
     if (!n) return retval;
     for (i=0; i<n; i++)
     {
-        Atom* btom = prevC->get_bond_by_idx(i)->btom;
-        if (!btom) continue;
-        if (!strcmp(btom->name, "CA")) prevCA = btom;
-        if (!strcmp(btom->name, "O" )) prevO = btom;
+        Atom* atom2 = prevC->get_bond_by_idx(i)->atom2;
+        if (!atom2) continue;
+        if (!strcmp(atom2->name, "CA")) prevCA = atom2;
+        if (!strcmp(atom2->name, "O" )) prevO = atom2;
     }
     Atom* localN  = get_atom("N");
     if (!localN) return retval;
@@ -3093,7 +3093,7 @@ LocRotation AminoAcid::rotate_backbone_abs(bb_rot_dir dir, float angle)
     if (aadef && aadef->proline_like) return retval;
 
     // Get the location of the previous C, and the location of the local C.
-    Atom *atom, *btom;
+    Atom *atom, *atom2;
 
     angle = M_PI+angle;
 
@@ -3101,42 +3101,42 @@ LocRotation AminoAcid::rotate_backbone_abs(bb_rot_dir dir, float angle)
     {
     case N_asc:
         atom = get_atom("N");
-        btom = get_atom("CA");
+        atom2 = get_atom("CA");
         break;
 
     case CA_asc:
         atom = get_atom("CA");
-        btom = get_atom("C");
+        atom2 = get_atom("C");
         break;
 
     case CA_desc:
         atom = get_atom("CA");
-        btom = get_atom("N");
+        atom2 = get_atom("N");
         break;
 
     case C_desc:
         atom = get_atom("C");
-        btom = get_atom("CA");
+        atom2 = get_atom("CA");
         break;
 
     default:
         cout << "Bad direction for " << *this << "; cannot rotate backbone." << endl;
         return retval;
     }
-    if (!atom || !btom)
+    if (!atom || !atom2)
     {
         cout << "Not found axial atom for " << *this << "; cannot rotate backbone." << endl;
         return retval;
     }
-    Bond* b = atom->get_bond_between(btom);
+    Bond* b = atom->get_bond_between(atom2);
     if (!b)
     {
-        atom->bond_to(btom, 1);
-        b = atom->get_bond_between(btom);
+        atom->bond_to(atom2, 1);
+        b = atom->get_bond_between(atom2);
     }
     if (!b)
     {
-        cout << "No bond between " << *this << ":" << atom->name << "-" << btom->name << "; cannot rotate backbone." << endl;
+        cout << "No bond between " << *this << ":" << atom->name << "-" << atom2->name << "; cannot rotate backbone." << endl;
         return retval;
     }
     if (!m_mcoord) b->can_rotate = true;
@@ -3148,13 +3148,13 @@ LocRotation AminoAcid::rotate_backbone_abs(bb_rot_dir dir, float angle)
     case N_asc:
     case CA_desc:
         atom = HN_or_substitute();
-        btom = get_atom("C");
+        atom2 = get_atom("C");
         break;
 
     case CA_asc:
     case C_desc:
         atom = get_atom("N");
-        btom = get_atom("O");
+        atom2 = get_atom("O");
         break;
 
     default:
@@ -3167,7 +3167,7 @@ LocRotation AminoAcid::rotate_backbone_abs(bb_rot_dir dir, float angle)
     float theta, step = 3, oldstep = 360;
     float bestrad=0, bestr;
 
-    if (!atom || !btom)
+    if (!atom || !atom2)
     {
         cout << "Not found reference atom for " << *this << "; cannot rotate backbone." << endl;
         return retval;
@@ -3175,14 +3175,14 @@ LocRotation AminoAcid::rotate_backbone_abs(bb_rot_dir dir, float angle)
 
     while (step > 0.01)
     {
-        bestr = atom->get_location().get_3d_distance(btom->get_location()) * 1000;
+        bestr = atom->get_location().get_3d_distance(atom2->get_location()) * 1000;
         for (theta=bestrad-oldstep; theta<bestrad+oldstep; theta+=step)
         {
             b->rotate(fiftyseventh*step, true);
-            float r = atom->get_location().get_3d_distance(btom->get_location());
+            float r = atom->get_location().get_3d_distance(atom2->get_location());
             #if 0
-            /*if (dir == N_asc)*/ cout << b->atom->name << "-" << b->btom->name << " rotation " << theta << ": "
-                << atom->name << "-" << btom->name << " distance = " << r << endl << flush;
+            /*if (dir == N_asc)*/ cout << b->atom->name << "-" << b->atom2->name << " rotation " << theta << ": "
+                << atom->name << "-" << atom2->name << " distance = " << r << endl << flush;
             #endif
             if (r < bestr)
             {
@@ -3210,7 +3210,7 @@ LocRotation AminoAcid::rotate_backbone_abs(bb_rot_dir dir, float angle)
 
 LocatedVector AminoAcid::rotate_backbone(bb_rot_dir direction, float angle)
 {
-    Atom *rotcen, *btom;
+    Atom *rotcen, *atom2;
     LocatedVector retval;
     Point rel, bloc;
     char aname[5], bname[5];
@@ -3261,22 +3261,22 @@ LocatedVector AminoAcid::rotate_backbone(bb_rot_dir direction, float angle)
         return retval;
     }
     retval.origin = rotcen->get_location();
-    btom = get_atom(bname);
-    if (!btom)
+    atom2 = get_atom(bname);
+    if (!atom2)
     {
         // cout << get_3letter() << residue_no << ":" << bname << "not found; cannot rotate backbone." << endl;
         return retval;
     }
 
-    Bond* b = rotcen->get_bond_between(btom);
+    Bond* b = rotcen->get_bond_between(atom2);
     if (!b) // || !b->can_rotate)
     {
-        // cout << "Non-rotatable bond " << *this << ":" << rotcen->name << "-" << btom->name << "; cannot rotate backbone." << endl;
+        // cout << "Non-rotatable bond " << *this << ":" << rotcen->name << "-" << atom2->name << "; cannot rotate backbone." << endl;
         retval.r = 0;		// Fail condition.
         return retval;
     }
 
-    rel = btom->get_location().subtract(retval.origin);
+    rel = atom2->get_location().subtract(retval.origin);
     SCoord v(rel);
     retval.phi = v.phi;
     retval.theta = v.theta;
@@ -3285,23 +3285,23 @@ LocatedVector AminoAcid::rotate_backbone(bb_rot_dir direction, float angle)
     // Rotate the local atoms that would be affected.
     if (direction == C_desc)
     {
-        btom = get_atom("N");
-        if (btom) btom->move(rotate3D(btom->get_location(), retval.origin, retval, angle));
+        atom2 = get_atom("N");
+        if (atom2) atom2->move(rotate3D(atom2->get_location(), retval.origin, retval, angle));
     }
     if (direction == CA_desc || direction == C_desc)
     {
-        btom = HN_or_substitute();
-        if (btom) btom->move(rotate3D(btom->get_location(), retval.origin, retval, angle));
+        atom2 = HN_or_substitute();
+        if (atom2) atom2->move(rotate3D(atom2->get_location(), retval.origin, retval, angle));
     }
     if (direction == N_asc)
     {
-        btom = get_atom("C");
-        if (btom) btom->move(rotate3D(btom->get_location(), retval.origin, retval, angle));
+        atom2 = get_atom("C");
+        if (atom2) atom2->move(rotate3D(atom2->get_location(), retval.origin, retval, angle));
     }
     if (direction == N_asc || direction == CA_asc || direction == C_desc)
     {
-        btom = get_atom("O");
-        if (btom) btom->move(rotate3D(btom->get_location(), retval.origin, retval, angle));
+        atom2 = get_atom("O");
+        if (atom2) atom2->move(rotate3D(atom2->get_location(), retval.origin, retval, angle));
     }
 
     // Include side chain atoms.

--- a/src/classes/aminoacid.cpp
+++ b/src/classes/aminoacid.cpp
@@ -153,14 +153,14 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
             strcpy(atoms[i]->aa3let, aa_defs[idx]._3let);
             atom_isheavy[i] = (atoms[i]->get_Z() != 1);
 
-            // If the atom is hydrogen, its Greek will be the same as its bond[0]->atom2. Otherwise, it will be one more.
+            // If the atom is hydrogen, its Greek will be the same as its bond[0]->get_atom2(). Otherwise, it will be one more.
             Bond* b0 = atoms[i]->get_bond_by_idx(0);
-            if (!b0 || !b0->atom2)
+            if (!b0 || !b0->get_atom2())
             {
                 cout << "Error in definition for " << aa_defs[idx].name << "." << endl;
                 throw 0xbadac1d;
             }
-            j = atom_idx_from_ptr(b0->atom2);
+            j = atom_idx_from_ptr(b0->get_atom2());
             if (j < 0)
             {
                 cout << "Error in definition for " << aa_defs[idx].name << "." << endl;
@@ -182,12 +182,12 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                     atoms[i]->fetch_bonds(ab);
                     for (j=0; ab[j]; j++)
                     {
-                        if (ab[j]->atom2
+                        if (ab[j]->get_atom2()
                                 &&
-                                ab[j]->atom2->get_family() == TETREL
+                                ab[j]->get_atom2()->get_family() == TETREL
                            )
                         {
-                            O = ab[j]->atom2->is_bonded_to(CHALCOGEN, 2);
+                            O = ab[j]->get_atom2()->is_bonded_to(CHALCOGEN, 2);
                             if (O)
                             {
                                 CA = atoms[i];
@@ -201,7 +201,7 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                                     numgrk[atom_Greek[k]]++;
                                 }
 
-                                C = ab[j]->atom2;
+                                C = ab[j]->get_atom2();
                                 C->name = new char[5];
                                 strcpy(C->name, "C");
                                 C->is_backbone = true;
@@ -227,11 +227,11 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                                     int n;
                                     for (n=0; ab[n]; n++)
                                     {
-                                        if (ab[n]->atom2 && ab[n]->atom2->get_Z() == 1)
+                                        if (ab[n]->get_atom2() && ab[n]->get_atom2()->get_Z() == 1)
                                         {
                                             if (!l)
                                             {
-                                                HN = ab[n]->atom2;
+                                                HN = ab[n]->get_atom2();
                                                 HN->name = new char[5];
                                                 strcpy(HN->name, "HN");
                                                 HN->is_backbone = true;
@@ -273,9 +273,9 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                 for (j=0; j<ag; j++)
                 {
                     if (!ab[j]) continue;
-                    if (ab[j]->atom2)
+                    if (ab[j]->get_atom2())
                     {
-                        k = atom_idx_from_ptr(ab[j]->atom2);
+                        k = atom_idx_from_ptr(ab[j]->get_atom2());
                         if (k >= 0 && !atom_Greek[k])
                         {
                             atom_Greek[k] = atom_Greek[i]+1;
@@ -298,10 +298,10 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                     for (j=0; j<ag; j++)
                     {
                          if (!ab[j]) continue;
-                        if (ab[j]->atom2)
+                        if (ab[j]->get_atom2())
                         {
-                            // cout << atoms[i]->name << " is bonded to " << ab[j]->atom2->name << name << endl;
-                            k = atom_idx_from_ptr(ab[j]->atom2);
+                            // cout << atoms[i]->name << " is bonded to " << ab[j]->get_atom2()->name << name << endl;
+                            k = atom_idx_from_ptr(ab[j]->get_atom2());
                             // cout << "Greek is " << atom_Greek[i] << " vs. bonded Greek " << atom_Greek[k] << endl;
                             if (atom_isheavy[k] && atom_Greek[k] > 0)
                             {
@@ -567,17 +567,17 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
             for (j=0; j<bg; j++)
             {
                 if (!bb[j]) break;
-                if (bb[j]->atom2 && bb[j]->atom2 < bb[j]->atom1)
+                if (bb[j]->get_atom2() && bb[j]->get_atom2() < bb[j]->get_atom1())
                 {
                     aabd[n] = new AABondDef();
-                    strcpy(aabd[n]->aname, bb[j]->atom1->name);
-                    strcpy(aabd[n]->bname, bb[j]->atom2->name);
-                    aabd[n]->Za = bb[j]->atom1->get_Z();
-                    aabd[n]->Zb = bb[j]->atom2->get_Z();
+                    strcpy(aabd[n]->aname, bb[j]->get_atom1()->name);
+                    strcpy(aabd[n]->bname, bb[j]->get_atom2()->name);
+                    aabd[n]->Za = bb[j]->get_atom1()->get_Z();
+                    aabd[n]->Zb = bb[j]->get_atom2()->get_Z();
                     aabd[n]->cardinality = bb[j]->cardinality;
-                    aabd[n]->acharge = bb[j]->atom1->get_charge();
+                    aabd[n]->acharge = bb[j]->get_atom1()->get_charge();
 
-                    if (!strcmp(bb[j]->atom1->name, "OH") && !strcmp(bb[j]->atom2->name, "CZ"))
+                    if (!strcmp(bb[j]->get_atom1()->name, "OH") && !strcmp(bb[j]->get_atom2()->name, "CZ"))
                     {
                         aabd[n]->can_rotate = false;
                         aabd[n]->can_flip = true;
@@ -586,49 +586,49 @@ AminoAcid::AminoAcid(const char letter, AminoAcid* prevaa, bool minintc, Protein
                     aabd[n]->can_rotate =
                         (	aabd[n]->cardinality <= 1.1
                             &&
-                            (	!bb[j]->atom1->is_pi() || !bb[j]->atom2->is_pi()	)
+                            (	!bb[j]->get_atom1()->is_pi() || !bb[j]->get_atom2()->is_pi()	)
                             &&
-                            (	!bb[j]->atom1->is_pi()
+                            (	!bb[j]->get_atom1()->is_pi()
                                 ||
-                                (   bb[j]->atom2->get_family() != PNICTOGEN
+                                (   bb[j]->get_atom2()->get_family() != PNICTOGEN
                                     &&
-                                    bb[j]->atom2->get_family() != CHALCOGEN
+                                    bb[j]->get_atom2()->get_family() != CHALCOGEN
                                 )
                                 ||
-                                bb[j]->atom2->is_bonded_to_pi(TETREL, false)
+                                bb[j]->get_atom2()->is_bonded_to_pi(TETREL, false)
                             )
                             &&
-                            (	!bb[j]->atom2->is_pi()
+                            (	!bb[j]->get_atom2()->is_pi()
                                 ||
-                                (   bb[j]->atom1->get_family() != PNICTOGEN
+                                (   bb[j]->get_atom1()->get_family() != PNICTOGEN
                                     &&
-                                    bb[j]->atom1->get_family() != CHALCOGEN
+                                    bb[j]->get_atom1()->get_family() != CHALCOGEN
                                 )
                                 ||
-                                bb[j]->atom1->is_bonded_to_pi(TETREL, false)
+                                bb[j]->get_atom1()->is_bonded_to_pi(TETREL, false)
                             )
                             &&
-                            (	bb[j]->atom1->get_family() != PNICTOGEN || !bb[j]->atom2->is_pi()	)
+                            (	bb[j]->get_atom1()->get_family() != PNICTOGEN || !bb[j]->get_atom2()->is_pi()	)
                         );
                     aabd[n]->can_flip =
                         (	aabd[n]->cardinality <= 1.1
                             &&
-                            (	!bb[j]->atom1->is_pi() || !bb[j]->atom2->is_pi()	)
+                            (	!bb[j]->get_atom1()->is_pi() || !bb[j]->get_atom2()->is_pi()	)
                             &&
                             (	(
-                                    bb[j]->atom1->is_pi()
+                                    bb[j]->get_atom1()->is_pi()
                                     &&
-                                    (   bb[j]->atom2->get_family() == PNICTOGEN || bb[j]->atom2->get_family() == CHALCOGEN    )
+                                    (   bb[j]->get_atom2()->get_family() == PNICTOGEN || bb[j]->get_atom2()->get_family() == CHALCOGEN    )
                                     &&
-                                    !bb[j]->atom2->is_bonded_to_pi(TETREL, false)
+                                    !bb[j]->get_atom2()->is_bonded_to_pi(TETREL, false)
                                 )
                                 ||
                                 (
-                                    bb[j]->atom2->is_pi()
+                                    bb[j]->get_atom2()->is_pi()
                                     &&
-                                    (   bb[j]->atom1->get_family() == PNICTOGEN || bb[j]->atom1->get_family() == CHALCOGEN    )
+                                    (   bb[j]->get_atom1()->get_family() == PNICTOGEN || bb[j]->get_atom1()->get_family() == CHALCOGEN    )
                                     &&
-                                    !bb[j]->atom1->is_bonded_to_pi(TETREL, false)
+                                    !bb[j]->get_atom1()->is_bonded_to_pi(TETREL, false)
                                 )
                             )
                         );
@@ -1980,7 +1980,7 @@ void AminoAcid::set_conditional_basicity(Molecule** nearby_mols)
                 if (fabs(atoms[j]->get_charge()) > 0.2) continue;
 
                 Atom* a = nearby_mols[i]->get_nearest_atom(atoms[j]->get_location());
-                if (a->get_Z() == 1) a = a->get_bond_by_idx(0)->atom2;
+                if (a->get_Z() == 1) a = a->get_bond_by_idx(0)->get_atom2();
                 if (!a) continue;
 
                 if (a->get_charge() <= -0.5 || a->is_conjugated_to_charge() <= -0.5)
@@ -1997,7 +1997,7 @@ void AminoAcid::set_conditional_basicity(Molecule** nearby_mols)
                     if (r >= cond_bas_hbond_distance_threshold) continue;
                     if (atoms[j]->get_Z() == 1)
                     {
-                        Atom* b = atoms[j]->get_bond_by_idx(0)->atom2;
+                        Atom* b = atoms[j]->get_bond_by_idx(0)->get_atom2();
                         if (!b) continue;
                         r = atoms[j]->distance_to(b);
                         if (r >= 1.333) continue;
@@ -2341,9 +2341,9 @@ float AminoAcid::hydrophilicity() const
             for (j=0; j<atoms[i]->get_geometry(); j++)
             {
                 Bond* b = atoms[i]->get_bond_by_idx(j);
-                if (b && b->atom2)
+                if (b && b->get_atom2())
                 {
-                    fam = b->atom2->get_family();
+                    fam = b->get_atom2()->get_family();
                     break;
                 }
             }
@@ -2473,7 +2473,7 @@ void AminoAcid::hydrogenate(bool steric_only)
         if (!bt) continue;
         bb = bt[0];
         if (!bb) continue;
-        heavy = bb->atom2;
+        heavy = bb->get_atom2();
         if (!heavy) continue;
 
         atoms[i]->residue = heavy->residue;
@@ -2547,7 +2547,7 @@ void AminoAcid::hydrogenate(bool steric_only)
                 if (bt)
                 {
                     bb = bt[0];
-                    if (bb && bb->atom2 == cursor)
+                    if (bb && bb->get_atom2() == cursor)
                         atomtmp[l++] = atoms[i];
                 }
             }
@@ -2577,7 +2577,7 @@ void AminoAcid::hydrogenate(bool steric_only)
                                 if (bt)
                                 {
                                     bb = bt[0];
-                                    if (bb && bb->atom2 == cursor)
+                                    if (bb && bb->get_atom2() == cursor)
                                         atomtmp[l++] = atoms[k];
                                 }
                             }
@@ -2604,7 +2604,7 @@ void AminoAcid::hydrogenate(bool steric_only)
                 if (bt)
                 {
                     bb = bt[0];
-                    if (bb && bb->atom2 == cursor)
+                    if (bb && bb->get_atom2() == cursor)
                         atomtmp[l++] = atoms[i];
                 }
             }
@@ -2725,7 +2725,7 @@ Atom* AminoAcid::previous_residue_C()
     if (!n) return NULL;
     for (i=0; i<n; i++)
     {
-        Atom* atom2 = N->get_bond_by_idx(i)->atom2;
+        Atom* atom2 = N->get_bond_by_idx(i)->get_atom2();
         if (!atom2) continue;
         if (atom2->residue == N->residue-1) return atom2;
     }
@@ -2740,7 +2740,7 @@ Atom* AminoAcid::next_residue_N()
     if (!n) return NULL;
     for (i=0; i<n; i++)
     {
-        Atom* atom2 = C->get_bond_by_idx(i)->atom2;
+        Atom* atom2 = C->get_bond_by_idx(i)->get_atom2();
         if (!atom2) continue;
         if (atom2->residue == C->residue+1) return atom2;
     }
@@ -2763,7 +2763,7 @@ Atom* AminoAcid::HN_or_substitute()
 
         for (i=0; i<g; i++)
         {
-            if (bb[i]->atom2 && strcmp(bb[i]->atom2->name, "CA")) return bb[i]->atom2;
+            if (bb[i]->get_atom2() && strcmp(bb[i]->get_atom2()->name, "CA")) return bb[i]->get_atom2();
         }
     }
     return retval;
@@ -2839,7 +2839,7 @@ LocRotation* AminoAcid::flatten()
     if (!n) return retval;
     for (i=0; i<n; i++)
     {
-        Atom* atom2 = prevC->get_bond_by_idx(i)->atom2;
+        Atom* atom2 = prevC->get_bond_by_idx(i)->get_atom2();
         if (!atom2) continue;
         if (!strcmp(atom2->name, "CA")) prevCA = atom2;
         if (!strcmp(atom2->name, "O" )) prevO = atom2;
@@ -3181,7 +3181,7 @@ LocRotation AminoAcid::rotate_backbone_abs(bb_rot_dir dir, float angle)
             b->rotate(fiftyseventh*step, true);
             float r = atom->get_location().get_3d_distance(atom2->get_location());
             #if 0
-            /*if (dir == N_asc)*/ cout << b->atom->name << "-" << b->atom2->name << " rotation " << theta << ": "
+            /*if (dir == N_asc)*/ cout << b->atom->name << "-" << b->get_atom2()->name << " rotation " << theta << ": "
                 << atom->name << "-" << atom2->name << " distance = " << r << endl << flush;
             #endif
             if (r < bestr)

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -219,7 +219,7 @@ Atom::Atom(const char* elem_sym)
 
     bonded_to = new Bond[abs(geometry)+4];
     int i;
-    for (i=0; i<geometry; i++) bonded_to[i].atom2 = nullptr;
+    for (i=0; i<geometry; i++) bonded_to[i].set_atom2(nullptr);
     strcpy(aa3let, "LIG");
     residue = 999;
 }
@@ -239,7 +239,7 @@ Atom::Atom(const char* elem_sym, const Point* l_location)
 
     bonded_to = new Bond[abs(geometry)+4];
     int i;
-    for (i=0; i<geometry; i++) bonded_to[i].atom2 = nullptr;
+    for (i=0; i<geometry; i++) bonded_to[i].set_atom2(nullptr);
     strcpy(aa3let, "LIG");
     residue = 999;
 }
@@ -260,7 +260,7 @@ Atom::Atom(const char* elem_sym, const Point* l_location, const float lcharge)
 
     bonded_to = new Bond[abs(geometry)];
     int i;
-    for (i=0; i<geometry; i++) bonded_to[i].atom2 = nullptr;
+    for (i=0; i<geometry; i++) bonded_to[i].set_atom2(nullptr);
     strcpy(aa3let, "LIG");
     residue = 999;
 }
@@ -331,7 +331,7 @@ Atom::Atom(FILE* is)
 
                     figure_out_valence();
                     bonded_to = new Bond[abs(geometry)];
-                    for (i=0; i<geometry; i++) bonded_to[i].atom2 = nullptr;
+                    for (i=0; i<geometry; i++) bonded_to[i].set_atom2(nullptr);
 
                     Point aloc(atof(words[5]), atof(words[6]),atof(words[7]));
                     location = aloc;
@@ -392,8 +392,8 @@ Atom::~Atom()
     {
         int i;
         for (i=0; i<geometry; i++)
-            if (bonded_to[i].atom2)
-                bonded_to[i].atom2->unbond(this);
+            if (bonded_to[i].get_atom2())
+                bonded_to[i].get_atom2()->unbond(this);
     }
 }
 
@@ -407,15 +407,15 @@ void Atom::unbond(Atom* atom2)
         int i;
         for (i=0; i<geometry; i++)
         {
-            if (bonded_to[i].atom2 == atom2)
+            if (bonded_to[i].get_atom2() == atom2)
             {
                 if (!reciprocity)
                 {
-                    bonded_to[i].atom2->reciprocity = true;
-                    bonded_to[i].atom2->unbond(this);		// RECURSION!
-                    bonded_to[i].atom2->reciprocity = false;
+                    bonded_to[i].get_atom2()->reciprocity = true;
+                    bonded_to[i].get_atom2()->unbond(this);		// RECURSION!
+                    bonded_to[i].get_atom2()->reciprocity = false;
                 }
-                bonded_to[i].atom2 = NULL;
+                bonded_to[i].set_atom2(nullptr);
                 bonded_to[i].cardinality=0;
                 bonded_to[i].can_rotate=0;
             }
@@ -428,13 +428,13 @@ void Atom::unbond_all()
     int i;
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
         {
-            bonded_to[i].atom2->reciprocity = true;
-            bonded_to[i].atom2->unbond(this);		// Potential for recursion!
-            bonded_to[i].atom2->reciprocity = false;
+            bonded_to[i].get_atom2()->reciprocity = true;
+            bonded_to[i].get_atom2()->unbond(this);		// Potential for recursion!
+            bonded_to[i].get_atom2()->reciprocity = false;
 
-            bonded_to[i].atom2 = NULL;
+            bonded_to[i].set_atom2(nullptr);
             bonded_to[i].cardinality=0;
             bonded_to[i].can_rotate=0;
         }
@@ -503,9 +503,9 @@ bool Atom::move_rel(SCoord* v)
     /*if (name && !strcmp(name, "CB"))
     {
     	Bond* b = get_bond_between("CA");
-    	if (b && b->atom2)
+    	if (b && b->get_atom2())
     	{
-    		float r = b->atom2->get_location().get_3d_distance(location.add(v));
+    		float r = b->get_atom2()->get_location().get_3d_distance(location.add(v));
     		if (r > 1.55) throw 0x7e57196;
     	}
     }*/
@@ -576,10 +576,10 @@ float Atom::get_charge()
 {
     if (Z == 1)
     {
-        if (bonded_to && bonded_to[0].atom2)
+        if (bonded_to && bonded_to[0].get_atom2())
         {
-            float bchg = bonded_to[0].atom2->charge;
-            if (!bchg) bchg = bonded_to[0].atom2->is_conjugated_to_charge();
+            float bchg = bonded_to[0].get_atom2()->charge;
+            if (!bchg) bchg = bonded_to[0].get_atom2()->is_conjugated_to_charge();
             if (bchg > 0) return bchg;
         }
     }
@@ -652,9 +652,9 @@ void Atom::fetch_bonds(Bond** result)
 
         for (i=0; i<geometry; i++)
         {
-            if (abs((__int64_t)(this) - (__int64_t)bonded_to[i].atom1) > memsanity) break;
-            if (!bonded_to[i].atom1) continue;
-            if (!bonded_to[i].atom1->Z) continue;
+            if (abs((__int64_t)(this) - (__int64_t)bonded_to[i].get_atom1()) > memsanity) break;
+            if (!bonded_to[i].get_atom1()) continue;
+            if (!bonded_to[i].get_atom1()->Z) continue;
             result[i] = &bonded_to[i];
         }
         result[i] = nullptr;
@@ -679,7 +679,7 @@ int Atom::get_bonded_atoms_count()
 {
     if (!bonded_to) return 0;
     int i, retval=0;
-    for (i=0; i<geometry; i++) if (bonded_to[i].atom2) retval++;
+    for (i=0; i<geometry; i++) if (bonded_to[i].get_atom2()) retval++;
     return retval;
 }
 
@@ -687,7 +687,7 @@ int Atom::get_bonded_heavy_atoms_count()
 {
     if (!bonded_to) return 0;
     int i, retval=0;
-    for (i=0; i<geometry; i++) if (bonded_to[i].atom2 && bonded_to[i].atom2->get_Z() > 1) retval++;
+    for (i=0; i<geometry; i++) if (bonded_to[i].get_atom2() && bonded_to[i].get_atom2()->get_Z() > 1) retval++;
     return retval;
 }
 
@@ -697,11 +697,11 @@ float Atom::is_bonded_to(Atom* latom2)
     int i;
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2
-            && abs(reinterpret_cast<long>(bonded_to[i].atom2) - reinterpret_cast<long>(bonded_to)) < memsanity
-            && bonded_to[i].atom2->get_Z() > 0 && bonded_to[i].atom2->get_Z() <= 118)
+        if (bonded_to[i].get_atom2()
+            && abs(reinterpret_cast<long>(bonded_to[i].get_atom2()) - reinterpret_cast<long>(bonded_to)) < memsanity
+            && bonded_to[i].get_atom2()->get_Z() > 0 && bonded_to[i].get_atom2()->get_Z() <= 118)
         {
-            if (bonded_to[i].atom2 == latom2) return bonded_to[i].cardinality;
+            if (bonded_to[i].get_atom2() == latom2) return bonded_to[i].cardinality;
         }
     }
     return 0;
@@ -712,8 +712,8 @@ bool Atom::shares_bonded_with(Atom* atom2)
     if (!bonded_to) return false;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2 && abs(reinterpret_cast<long>(bonded_to[i].atom2) - reinterpret_cast<long>(this)) < memsanity)
-            if (bonded_to[i].atom2->is_bonded_to(atom2)) return true;
+        if (bonded_to[i].get_atom2() && abs(reinterpret_cast<long>(bonded_to[i].get_atom2()) - reinterpret_cast<long>(this)) < memsanity)
+            if (bonded_to[i].get_atom2()->is_bonded_to(atom2)) return true;
     return false;
 }
 
@@ -730,11 +730,11 @@ bool Atom::check_Greek_continuity()
     int i;
     for (i=0; i<origgeo; i++)
     {
-        if (!bonded_to[i].atom2) continue;
-        int b = greek_from_aname(bonded_to[i].atom2->name);
+        if (!bonded_to[i].get_atom2()) continue;
+        int b = greek_from_aname(bonded_to[i].get_atom2()->name);
         if (b>=0 && b == a-1)
         {
-            if (!bonded_to[i].atom2->is_bonded_to(this)) throw 0xface;
+            if (!bonded_to[i].get_atom2()->is_bonded_to(this)) throw 0xface;
             else return true;
         }
     }
@@ -747,12 +747,12 @@ Atom* Atom::is_bonded_to(const char* element)
     if (!bonded_to) return 0;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
             if (!strcmp(element, "*")
                 ||
-                !strcmp(bonded_to[i].atom2->get_elem_sym(), element)
+                !strcmp(bonded_to[i].get_atom2()->get_elem_sym(), element)
                )
-                return bonded_to[i].atom2;
+                return bonded_to[i].get_atom2();
     return 0;
 }
 
@@ -761,8 +761,8 @@ int Atom::num_bonded_to(const char* element)
     if (!bonded_to) return 0;
     int i, j=0;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
-            if (!strcmp(bonded_to[i].atom2->get_elem_sym(), element)
+        if (bonded_to[i].get_atom2())
+            if (!strcmp(bonded_to[i].get_atom2()->get_elem_sym(), element)
                )
                 j++;
     return j;
@@ -773,10 +773,10 @@ int Atom::num_bonded_to_in_ring(const char* element, Ring* member_of)
     if (!bonded_to) return 0;
     int i, j=0;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
-            if (!strcmp(bonded_to[i].atom2->get_elem_sym(), element)
+        if (bonded_to[i].get_atom2())
+            if (!strcmp(bonded_to[i].get_atom2()->get_elem_sym(), element)
                 &&
-                bonded_to[i].atom2->is_in_ring(member_of)
+                bonded_to[i].get_atom2()->is_in_ring(member_of)
                )
                 j++;
     return j;
@@ -787,8 +787,8 @@ Bond* Atom::get_bond_between(Atom* atom2)
     if (!bonded_to) return 0;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
-            if (bonded_to[i].atom2 == atom2)
+        if (bonded_to[i].get_atom2())
+            if (bonded_to[i].get_atom2() == atom2)
                 return &bonded_to[i];
     return 0;
 }
@@ -798,8 +798,8 @@ Bond* Atom::get_bond_between(const char* bname)
     if (!bonded_to) return 0;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
-            if (bonded_to[i].atom2 && !strcmp( bonded_to[i].atom2->name, bname ))
+        if (bonded_to[i].get_atom2())
+            if (bonded_to[i].get_atom2() && !strcmp( bonded_to[i].get_atom2()->name, bname ))
                 return &bonded_to[i];
     return 0;
 }
@@ -809,8 +809,8 @@ int Atom::get_idx_bond_between(Atom* atom2)
     if (!bonded_to) return -1;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
-            if (bonded_to[i].atom2 == atom2)
+        if (bonded_to[i].get_atom2())
+            if (bonded_to[i].get_atom2() == atom2)
                 return i;
     return -1;
 }
@@ -820,12 +820,12 @@ Atom* Atom::is_bonded_to(const char* element, const int lcardinality)
     if (!bonded_to) return 0;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
-            if (!strcmp(bonded_to[i].atom2->get_elem_sym(), element)
+        if (bonded_to[i].get_atom2())
+            if (!strcmp(bonded_to[i].get_atom2()->get_elem_sym(), element)
                     &&
                     bonded_to[i].cardinality == lcardinality
                )
-                return bonded_to[i].atom2;
+                return bonded_to[i].get_atom2();
     return 0;
 }
 
@@ -834,11 +834,11 @@ Atom* Atom::is_bonded_to(const int family)
     if (!bonded_to) return 0;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
             if (   
-                bonded_to[i].atom2->get_family() == family
+                bonded_to[i].get_atom2()->get_family() == family
                )
-                return bonded_to[i].atom2;
+                return bonded_to[i].get_atom2();
     return 0;
 }
 
@@ -847,13 +847,13 @@ Atom* Atom::is_bonded_to(const int family, const int lcardinality)
     if (!bonded_to) return 0;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
             if (    
-                bonded_to[i].atom2->get_family() == family
+                bonded_to[i].get_atom2()->get_family() == family
                 &&
                 bonded_to[i].cardinality == lcardinality
                )
-                return bonded_to[i].atom2;
+                return bonded_to[i].get_atom2();
     return 0;
 }
 
@@ -862,13 +862,13 @@ Atom* Atom::is_bonded_to_pi(const int family, const bool other_atoms_pi)
     if (!bonded_to) return 0;
     int i;
     for (i=0; i<geometry; i++)
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
             if (    
-                bonded_to[i].atom2->get_family() == family
+                bonded_to[i].get_atom2()->get_family() == family
                 &&
-                bonded_to[i].atom2->is_pi() == other_atoms_pi
+                bonded_to[i].get_atom2()->is_pi() == other_atoms_pi
                )
-                return bonded_to[i].atom2;
+                return bonded_to[i].get_atom2();
     return 0;
 }
 
@@ -894,7 +894,7 @@ bool Atom::bond_to(Atom* latom2, float lcard)
         latom2->geov=0;
     }
 
-    if (!reciprocity && !bonded_to[0].atom2)
+    if (!reciprocity && !bonded_to[0].get_atom2())
     {
         mirror_geo = (geometry==3 && lcard >= 1.5 && lcard<=2) ? 0 : -1;
         //if (mirror_geo >= 0) cout << name << " mirrors the geometry of " << latom2->name << "(" << latom2->geometry << ")" << endl;
@@ -902,10 +902,10 @@ bool Atom::bond_to(Atom* latom2, float lcard)
 
     for (i=0; i<geometry; i++)
     {
-        if (!bonded_to[i].atom2)
+        if (!bonded_to[i].get_atom2())
         {
-            bonded_to[i].atom1 = this;
-            bonded_to[i].atom2 = latom2;
+            bonded_to[i].set_atom1(this);
+            bonded_to[i].set_atom2(latom2);
             bonded_to[i].cardinality = lcard;
             bonded_to[i].can_rotate = (lcard == 1
                                        && Z != 1
@@ -991,25 +991,25 @@ float Atom::is_polar()
         polarity = 0;
         for (i=0; i<valence; i++)
         {
-            if (bonded_to[i].atom2)
+            if (bonded_to[i].get_atom2())
             {
                 n++;
 
-                float f = (bonded_to[i].atom2->elecn - elecn);
-                if (Z==1 && bonded_to[i].atom2->family == TETREL) f = 0;
+                float f = (bonded_to[i].get_atom2()->elecn - elecn);
+                if (Z==1 && bonded_to[i].get_atom2()->family == TETREL) f = 0;
 
                 for (j=0; j<valence; j++)
                 {
                     if (j==i) continue;
-                    if (!bonded_to[j].atom2) continue;
-                    float e = (bonded_to[j].atom2->elecn - elecn);
-                    e *= cos(find_3d_angle(bonded_to[i].atom2->location, bonded_to[j].atom2->location, location));
+                    if (!bonded_to[j].get_atom2()) continue;
+                    float e = (bonded_to[j].get_atom2()->elecn - elecn);
+                    e *= cos(find_3d_angle(bonded_to[i].get_atom2()->location, bonded_to[j].get_atom2()->location, location));
                     f += e;
                 }
 
                 polarity += f;
                 #if _dbg_polar_calc
-                cout << "# " << name << " is bonded to " << bonded_to[i].atom2->name << " " << f << ", ";
+                cout << "# " << name << " is bonded to " << bonded_to[i].get_atom2()->name << " " << f << ", ";
                 #endif
             }
         }
@@ -1094,7 +1094,7 @@ bool Atom::is_pi()
         n=0;
         for (i=0; i<geometry; i++)
         {
-            if (bonded_to[i].atom2) n++;
+            if (bonded_to[i].get_atom2()) n++;
         }
 
         if (n > 3) return false;
@@ -1102,7 +1102,7 @@ bool Atom::is_pi()
 
     if (Z == 1)
     {
-        if (bonded_to[0].atom2 && bonded_to[0].atom2->Z > 1) return bonded_to[0].atom2->is_pi();
+        if (bonded_to[0].get_atom2() && bonded_to[0].get_atom2()->Z > 1) return bonded_to[0].get_atom2()->is_pi();
     }
 
     if (family == PNICTOGEN && is_bonded_to_pi(TETREL, true) && !is_bonded_to(CHALCOGEN)) return true;
@@ -1124,7 +1124,7 @@ bool Atom::is_amide()
             int i;
             for (i=0; i<geometry; i++)
             {
-                Atom* C = bonded_to[i].atom2;
+                Atom* C = bonded_to[i].get_atom2();
                 if (C)
                 {
                     int fam = C->get_family();
@@ -1253,11 +1253,11 @@ void Bond::fill_moves_with_cache()
     if (!b[0]) return;
     for (i=0; b[i]; i++)
     {
-        if (b[i]->atom2 && b[i]->atom2 != atom1 && b[i]->atom2->residue == atom2->residue)
+        if (b[i]->get_atom2() && b[i]->get_atom2() != atom1 && b[i]->get_atom2()->residue == atom2->residue)
         {
-            attmp[tmplen++] = b[i]->atom2;
-            b[i]->atom2->used = true;
-            if (_DBGMOVES) cout << b[i]->atom2->name << " ";
+            attmp[tmplen++] = b[i]->get_atom2();
+            b[i]->get_atom2()->used = true;
+            if (_DBGMOVES) cout << b[i]->get_atom2()->name << " ";
         }
     }
 
@@ -1277,17 +1277,17 @@ void Bond::fill_moves_with_cache()
             {
                 for (i=0; b[i]; i++)
                 {
-                    if (_DBGMOVES) if (b[i]->atom2) cout << "(" << attmp[j]->name << "-" << b[i]->atom2->name << (b[i]->atom2->used ? "*" : "") << "?) ";
-                    if (b[i]->atom2 && !b[i]->atom2->used && b[i]->atom2 != atom1 && b[i]->atom2->residue == atom2->residue)
+                    if (_DBGMOVES) if (b[i]->get_atom2()) cout << "(" << attmp[j]->name << "-" << b[i]->get_atom2()->name << (b[i]->get_atom2()->used ? "*" : "") << "?) ";
+                    if (b[i]->get_atom2() && !b[i]->get_atom2()->used && b[i]->get_atom2() != atom1 && b[i]->get_atom2()->residue == atom2->residue)
                     {
-                        if (b[i]->atom2->in_same_ring_as(atom1))
+                        if (b[i]->get_atom2()->in_same_ring_as(atom1))
                         {
-                            b[i]->atom2->used = true;
+                            b[i]->get_atom2()->used = true;
                             continue;
                         }
-                        attmp[tmplen++] = b[i]->atom2;
-                        b[i]->atom2->used = true;
-                        if (_DBGMOVES) cout << b[i]->atom2->name << " " << flush;
+                        attmp[tmplen++] = b[i]->get_atom2();
+                        b[i]->get_atom2()->used = true;
+                        if (_DBGMOVES) cout << b[i]->get_atom2()->name << " " << flush;
                         k++;
                     }
                 }
@@ -1396,13 +1396,13 @@ void Atom::print_bond_angles()
 
     for (i=0; i<valence; i++)
     {
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
         {
             for (j=i+1; j<valence; j++)
             {
-                if (bonded_to[j].atom2)
+                if (bonded_to[j].get_atom2())
                 {
-                    float theta = find_3d_angle(bonded_to[i].atom2->location, bonded_to[j].atom2->location, location);
+                    float theta = find_3d_angle(bonded_to[i].get_atom2()->location, bonded_to[j].get_atom2()->location, location);
                     cout << " " << (theta * fiftyseven);
                 }
             }
@@ -1666,12 +1666,12 @@ float Ring::flip_atom(Atom* wa)
                 float vxtheta = -find_angle_along_vector(wa->get_location(), ol, origin, axis);
                 for (i=0; wbonds[i]; i++)
                 {
-                    if (!wbonds[i]->atom2) continue;
-                    if (wbonds[i]->atom2->in_same_ring_as(wa)) continue;
+                    if (!wbonds[i]->get_atom2()) continue;
+                    if (wbonds[i]->get_atom2()->in_same_ring_as(wa)) continue;
 
-                    Point lpt = wbonds[i]->atom2->get_location();
+                    Point lpt = wbonds[i]->get_atom2()->get_location();
                     lpt = rotate3D(lpt, origin, axis, vxtheta);
-                    wbonds[i]->atom2->move(lpt);
+                    wbonds[i]->get_atom2()->move(lpt);
 
                     Atom* movesw[1024];
                     wbonds[i]->fetch_moves_with_atom2(movesw);
@@ -1858,7 +1858,7 @@ void Atom::swing_all(int startat)
 
     for (i=startat; i<geometry; i++)
     {
-        if (bonded_to[i].atom2) bonded_to[i].swing(v[i]);
+        if (bonded_to[i].get_atom2()) bonded_to[i].swing(v[i]);
     }
 }
 
@@ -1872,12 +1872,12 @@ float Atom::get_bond_angle_anomaly(SCoord v, Atom* ignore)
     //cout << " -=- " << lga*fiftyseven << " | ";
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
         {
-            if (bonded_to[i].atom2 == ignore) continue;
+            if (bonded_to[i].get_atom2() == ignore) continue;
 
-            //cout << bonded_to[i].atom2->location << " - " << location;
-            SCoord vb = bonded_to[i].atom2->location.subtract(location);
+            //cout << bonded_to[i].get_atom2()->location << " - " << location;
+            SCoord vb = bonded_to[i].get_atom2()->location.subtract(location);
             //cout << " = " << (Point)vb << endl;
             float theta = find_3d_angle(v, vb, Point(0,0,0));
             anomaly += fabs(theta-lga);
@@ -1900,15 +1900,15 @@ float Atom::get_geometric_bond_angle()
     //cout << name << " " << origgeo << " ";
 
     int i, bonded_atoms = 0;
-    for (i=0; i<lgeo; i++) if (bonded_to[i].atom2) bonded_atoms++;
+    for (i=0; i<lgeo; i++) if (bonded_to[i].get_atom2()) bonded_atoms++;
 
     for (i=0; i<lgeo; i++)
     {
         float bcard = bonded_to[i].cardinality;
-        if (bonded_to[i].atom2 && bcard > 1)
+        if (bonded_to[i].get_atom2() && bcard > 1)
         {
             lgeo -= ((i&1) ? floor(bcard-1) : ceil(bcard-1));		// lgeo is an integer so treat two 1.5 bonds the same as a 1 and a 2.
-            //cout << bonded_to[i].atom2->name << "-" << bcard << " ";
+            //cout << bonded_to[i].get_atom2()->name << "-" << bcard << " ";
         }
     }
     if (lgeo < bonded_atoms) lgeo = bonded_atoms;
@@ -1947,9 +1947,9 @@ Bond* Atom::get_bond_closest_to(Point pt)
 
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
         {
-            float r = bonded_to[i].atom2->location.get_3d_distance(pt);
+            float r = bonded_to[i].get_atom2()->location.get_3d_distance(pt);
             if (r < rmin)
             {
                 retval = &bonded_to[i];
@@ -1993,9 +1993,9 @@ SCoord* Atom::get_geometry_aligned_to_bonds(bool prevent_infinite_loop)
     // #259 fix:
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2)
+        if (bonded_to[i].get_atom2())
         {
-            Rotation rot = align_points_3d(location.add(geov[i]), bonded_to[i].atom2->location, location);
+            Rotation rot = align_points_3d(location.add(geov[i]), bonded_to[i].get_atom2()->location, location);
             for (l=0; l<geometry; l++)
             {
                 Point pt = geov[l];
@@ -2004,23 +2004,23 @@ SCoord* Atom::get_geometry_aligned_to_bonds(bool prevent_infinite_loop)
 
             for (j=i+1; j<geometry; j++)
             {
-                if (abs((__int64_t)(bonded_to) - (__int64_t)bonded_to[j].atom2) > memsanity) break;
-                if (bonded_to[j].atom2)
+                if (abs((__int64_t)(bonded_to) - (__int64_t)bonded_to[j].get_atom2()) > memsanity) break;
+                if (bonded_to[j].get_atom2())
                 {
-                    float theta = find_angle_along_vector(location.add(geov[j]), bonded_to[j].atom2->location, location, geov[i]);
+                    float theta = find_angle_along_vector(location.add(geov[j]), bonded_to[j].get_atom2()->location, location, geov[i]);
                     for (l=0; l<geometry; l++)
                         geov[l] = rotate3D(geov[l], center, geov[i], theta);
                     
                     for (k=j+1; k<geometry; k++)
                     {
-                        if (bonded_to[k].atom2)
+                        if (bonded_to[k].get_atom2())
                         {
                             for (l=j+1; l<geometry; l++)
                             {
-                                if (!bonded_to[l].atom2)
+                                if (!bonded_to[l].get_atom2())
                                 {
-                                    float ktheta = find_3d_angle(bonded_to[k].atom2->location, location.add(geov[k]), location);
-                                    float ltheta = find_3d_angle(bonded_to[k].atom2->location, location.add(geov[l]), location);
+                                    float ktheta = find_3d_angle(bonded_to[k].get_atom2()->location, location.add(geov[k]), location);
+                                    float ltheta = find_3d_angle(bonded_to[k].get_atom2()->location, location.add(geov[l]), location);
 
                                     if (ltheta < ktheta)
                                     {
@@ -2050,7 +2050,7 @@ SCoord* Atom::get_geometry_aligned_to_bonds(bool prevent_infinite_loop)
         j = k = 0;
         for (i = 0; i < geometry; i++)
         {
-            if (bonded_to[i].atom2)
+            if (bonded_to[i].get_atom2())
             {
                 j++;
                 k = i;
@@ -2060,9 +2060,9 @@ SCoord* Atom::get_geometry_aligned_to_bonds(bool prevent_infinite_loop)
         if (j == 1)
         {
             // SCoord align_to[3];
-            // for (i=0; i<3; i++) align_to[i] = bonded_to[k].atom2->geov[i];
+            // for (i=0; i<3; i++) align_to[i] = bonded_to[k].get_atom2()->geov[i];
 
-            if (bonded_to[k].atom2->is_pi()) mirror_geo = k;
+            if (bonded_to[k].get_atom2()->is_pi()) mirror_geo = k;
         }
     }
 
@@ -2071,24 +2071,24 @@ SCoord* Atom::get_geometry_aligned_to_bonds(bool prevent_infinite_loop)
     {
         Bond* b = &bonded_to[mirror_geo];
         if (_DBGGEO) cout << name << " location: " << location.printable() << endl;
-        if (_DBGGEO) cout << b->atom2->name << " location: " << b->atom2->location.printable() << endl;
-        geov[0] = v_from_pt_sub(b->atom2->location, location);
+        if (_DBGGEO) cout << b->get_atom2()->name << " location: " << b->get_atom2()->location.printable() << endl;
+        geov[0] = v_from_pt_sub(b->get_atom2()->location, location);
         geov[0].r = 1;
         Point _4avg[2];
-        _4avg[0] = b->atom2->location;
+        _4avg[0] = b->get_atom2()->location;
         _4avg[1] = location;
         Point avg = average_of_points(_4avg, 2);
         if (_DBGGEO) cout << "avg: " << avg.printable() << endl;
 
         j=1;
-        SCoord* bgeov = b->atom2->get_geometry_aligned_to_bonds(true);		// RECURSION!
+        SCoord* bgeov = b->get_atom2()->get_geometry_aligned_to_bonds(true);		// RECURSION!
 
-        for (i=0; i<b->atom2->geometry; i++)
+        for (i=0; i<b->get_atom2()->geometry; i++)
         {
-            if (!b->atom2->bonded_to[i].atom2 || b->atom2->bonded_to[i].atom2 != this)
+            if (!b->get_atom2()->bonded_to[i].get_atom2() || b->get_atom2()->bonded_to[i].get_atom2() != this)
             {
                 Point bgp(&bgeov[i]);
-                bgp = bgp.add(b->atom2->location);
+                bgp = bgp.add(b->get_atom2()->location);
                 if (_DBGGEO) cout << "bgp: " << bgp.printable() << " from SCoord φ=" << bgeov[i].phi << " θ=" << bgeov[i].theta << " r=" << bgeov[i].r << endl;
                 Point mirr = avg.subtract(bgp.subtract(&avg));
                 if (_DBGGEO) cout << "mirr: " << mirr.printable() << endl;
@@ -2121,14 +2121,14 @@ SCoord Atom::get_next_free_geometry(float lcard)
     else
     {
         int i;
-        for (i=0; bonded_to[i].atom2; i++);	// Get count.
+        for (i=0; bonded_to[i].get_atom2(); i++);	// Get count.
 
         if (i >= geometry) i=0;
 
         int j=i;
         if (geometry == 4 && swapped_chirality && i >= 2) i ^= 1;
         if (geometry == 3 && EZ_flip && i >= 1) i = 3-i;
-        // if (bonded_to[i].atom2) i=j;			// For some reason, this line makes everything go very wrong.
+        // if (bonded_to[i].get_atom2()) i=j;			// For some reason, this line makes everything go very wrong.
         if (geometry == 4 && chirality_unspecified)
         {
             for (i=0; i<geometry; i++)
@@ -2140,8 +2140,8 @@ SCoord Atom::get_next_free_geometry(float lcard)
                 if (!strcmp(name, "Tumbolia")) cout << i << "*: " << (Point)v[i] << endl;
                 for (j=0; j<geometry; j++)
                 {
-                    if (!bonded_to[j].atom2) continue;
-                    Point pt1 = bonded_to[j].atom2->location.subtract(location);
+                    if (!bonded_to[j].get_atom2()) continue;
+                    Point pt1 = bonded_to[j].get_atom2()->location.subtract(location);
                     pt1.scale(1);
                     float r = pt1.get_3d_distance(pt);
                     if (!strcmp(name, "Tumbolia")) cout << j << ":: " << pt1 << " " << r << endl;
@@ -2167,7 +2167,7 @@ int Atom::get_idx_next_free_geometry()
     else
     {
         int i;
-        for (i=0; i < geometry && bonded_to[i].atom2; i++);	// Get count.
+        for (i=0; i < geometry && bonded_to[i].get_atom2(); i++);	// Get count.
         if (i >= geometry) i=0;
         if (geometry == 4 && swapped_chirality && i >= 2) i ^= 1;
         if (geometry == 3 && EZ_flip && i >= 1) i = 3-i;
@@ -2181,7 +2181,7 @@ int Atom::get_count_pi_bonds()
     int i, retval=0;
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2 && bonded_to[i].cardinality > 1 && bonded_to[i].cardinality <= 2.1) retval++;
+        if (bonded_to[i].get_atom2() && bonded_to[i].cardinality > 1 && bonded_to[i].cardinality <= 2.1) retval++;
     }
     return retval;
 }
@@ -2193,10 +2193,10 @@ float Atom::get_sum_pi_bonds()
     float retval=0;
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2 && bonded_to[i].atom2->Z > 1)
+        if (bonded_to[i].get_atom2() && bonded_to[i].get_atom2()->Z > 1)
         {
             if (bonded_to[i].cardinality > 1 && bonded_to[i].cardinality <= 2.1) retval += bonded_to[i].cardinality;
-            else if (bonded_to[i].cardinality == 1 && bonded_to[i].atom2->is_pi()) retval += bonded_to[i].cardinality;
+            else if (bonded_to[i].cardinality == 1 && bonded_to[i].get_atom2()->is_pi()) retval += bonded_to[i].cardinality;
         }
     }
     return retval;
@@ -2311,6 +2311,67 @@ int Bond::count_heavy_moves_with_atom2()
     }
     return j;
 }
+
+#if bond_reciprocity_fix
+Atom* Bond::get_atom1()
+{
+    if (reversed)
+    {
+        if (reversed->atom2 != atom1)
+        {
+            #if _dbg_unreciprocated_bonds
+            throw 0x20240531;
+            #endif
+
+            if (abs(static_cast<int>((uint64_t)reversed->atom2 - (uint64_t)atom2)) < abs(static_cast<int>((uint64_t)atom1 - (uint64_t)atom2)))
+            {
+                atom1 = reversed->atom2;
+            }
+            else
+            {
+                reversed->atom2 = atom1;
+            }
+        }
+    }
+    return atom1;
+}
+
+Atom* Bond::get_atom2()
+{
+    if (reversed)
+    {
+        if (reversed->atom1 != atom2)
+        {
+            #if _dbg_unreciprocated_bonds
+            throw 0x20240531;
+            #endif
+
+            if (abs(static_cast<int>((uint64_t)reversed->atom1 - (uint64_t)atom1)) < abs(static_cast<int>((uint64_t)atom2 - (uint64_t)atom1)))
+            {
+                atom2 = reversed->atom1;
+            }
+            else
+            {
+                reversed->atom1 = atom2;
+            }
+        }
+    }
+    return atom2;
+}
+
+void Bond::set_atom1(Atom* a)
+{
+    atom1 = a;
+    if (reversed) reversed->atom2 = a;
+}
+
+void Bond::set_atom2(Atom* a)
+{
+    atom2 = a;
+    if (reversed) reversed->atom1 = a;
+}
+
+#endif
 
 Bond* Bond::get_reversed()
 {
@@ -2461,16 +2522,16 @@ float Atom::is_conjugated_to_charge(Atom* bir, Atom* c)
     int i;
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2
+        if (bonded_to[i].get_atom2()
             &&
-            bonded_to[i].atom2 != c
+            bonded_to[i].get_atom2() != c
             &&
-            bonded_to[i].atom2 != bir
+            bonded_to[i].get_atom2() != bir
             &&
-            bonded_to[i].atom2->is_pi()
+            bonded_to[i].get_atom2()->is_pi()
         )
         {
-            float f = bonded_to[i].atom2->origchg;
+            float f = bonded_to[i].get_atom2()->origchg;
             if (f)
             {
                 bir->recursion_counter = 0;
@@ -2478,7 +2539,7 @@ float Atom::is_conjugated_to_charge(Atom* bir, Atom* c)
             }
 
             // DANGER: RECURSION.
-            f = bonded_to[i].atom2->is_conjugated_to_charge(bir, this);
+            f = bonded_to[i].get_atom2()->is_conjugated_to_charge(bir, this);
             if (f)
             {
                 bir->recursion_counter = 0;
@@ -2495,7 +2556,7 @@ float Atom::is_conjugated_to_charge(Atom* bir, Atom* c)
 
 bool Atom::is_conjugated_to(Atom* a, Atom* bir, Atom* c)
 {
-    if (a->Z < 2) return (is_conjugated_to(a->bonded_to[0].atom2));
+    if (a->Z < 2) return (is_conjugated_to(a->bonded_to[0].get_atom2()));
 
     if (!this || !a) return false;
     if (!is_pi() || !a->is_pi()) return false;
@@ -2525,18 +2586,18 @@ bool Atom::is_conjugated_to(Atom* a, Atom* bir, Atom* c)
         int i;
         for (i=0; i<geometry; i++)
         {
-            if (bonded_to[i].atom2
+            if (bonded_to[i].get_atom2()
                 &&
-                (abs((__int64_t)(this) - (__int64_t)bonded_to[i].atom2) < memsanity)
+                (abs((__int64_t)(this) - (__int64_t)bonded_to[i].get_atom2()) < memsanity)
                 &&
-                bonded_to[i].atom2 != c
+                bonded_to[i].get_atom2() != c
                 &&
-                bonded_to[i].atom2 != bir
+                bonded_to[i].get_atom2() != bir
                 &&
-                bonded_to[i].atom2->is_pi()
+                bonded_to[i].get_atom2()->is_pi()
                 &&
                 // DANGER: RECURSION.
-                bonded_to[i].atom2->is_conjugated_to(a, bir, this)
+                bonded_to[i].get_atom2()->is_conjugated_to(a, bir, this)
                )
             {
                 bir->recursion_counter = 0;
@@ -2572,20 +2633,20 @@ std::vector<Atom*> Atom::get_conjugated_atoms(Atom* bir, Atom* c)
     int i;
     for (i=0; i<geometry; i++)
     {
-        if (bonded_to[i].atom2
+        if (bonded_to[i].get_atom2()
             &&
-            bonded_to[i].atom2 != c
+            bonded_to[i].get_atom2() != c
             &&
-            bonded_to[i].atom2 != bir
+            bonded_to[i].get_atom2() != bir
             &&
-            bonded_to[i].atom2->is_pi()
+            bonded_to[i].get_atom2()->is_pi()
             )
         {
             int n = casf.size();
-            casf.push_back(bonded_to[i].atom2);
+            casf.push_back(bonded_to[i].get_atom2());
 
             // DANGER: RECURSION.
-            std::vector<Atom*> lcasf = bonded_to[i].atom2->get_conjugated_atoms(bir, this);
+            std::vector<Atom*> lcasf = bonded_to[i].get_atom2()->get_conjugated_atoms(bir, this);
         }
     }
 
@@ -3031,13 +3092,13 @@ Atom* Atom::get_heaviest_bonded_atom_that_isnt(Atom* e)
 
     for (i=0; i<geometry; i++)
     {
-        if (!bonded_to[i].atom2) continue;
-        if (abs((__int64_t)(bonded_to) - (__int64_t)bonded_to[i].atom2) > memsanity) continue;
-        if (bonded_to[i].atom2 == e) continue;
-        if (bonded_to[i].atom2->at_wt > wt)
+        if (!bonded_to[i].get_atom2()) continue;
+        if (abs((__int64_t)(bonded_to) - (__int64_t)bonded_to[i].get_atom2()) > memsanity) continue;
+        if (bonded_to[i].get_atom2() == e) continue;
+        if (bonded_to[i].get_atom2()->at_wt > wt)
         {
-            wt = bonded_to[i].atom2->at_wt;
-            result = bonded_to[i].atom2;
+            wt = bonded_to[i].get_atom2()->at_wt;
+            result = bonded_to[i].get_atom2();
         }
     }
 
@@ -3054,9 +3115,10 @@ std::ostream& operator<<(std::ostream& os, const Atom& a)
 
 std::ostream& operator<<(std::ostream& os, const Bond& b)
 {
-    os << b.atom1->name;
+    Bond lb = b;
+    os << lb.get_atom1()->name;
     os << cardinality_printable(b.cardinality);
-    os << b.atom2->name;
+    os << lb.get_atom2()->name;
 
     return os;
 }

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -81,7 +81,7 @@ public:
     int count_heavy_moves_with_atom();
     int count_heavy_moves_with_atom2();
     Bond* get_reversed();
-    void swing(SCoord newdir);		// Rotate atom2, and all its moves_with atoms, about atom so that the bond points to newdir.
+    void swing(SCoord newdir);		// Rotate atom2, and all its moves_with atoms, about atom1 so that the bond points to newdir.
 
 protected:
     Atom* atom1 = nullptr;

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -39,8 +39,8 @@ class Atom;
 class Bond
 {
 public:
-    Atom* atom = 0;
-    Atom* btom = 0;
+    Atom* atom1 = 0;
+    Atom* atom2 = 0;
     float cardinality=0;			// aromatic bonds = 1.5.
     bool can_rotate=false;
     bool can_flip=false;
@@ -64,19 +64,19 @@ public:
     Point ring_rotate(float angle_radians, Atom* stop_at);
     void clear_moves_with_cache()
     {
-        moves_with_btom = 0;
+        moves_with_atom2 = 0;
     }
-    void fetch_moves_with_btom(Atom** result);
-    int count_moves_with_btom();
+    void fetch_moves_with_atom2(Atom** result);
+    int count_moves_with_atom2();
     int count_heavy_moves_with_atom();
-    int count_heavy_moves_with_btom();
+    int count_heavy_moves_with_atom2();
     Bond* get_reversed();
-    void swing(SCoord newdir);		// Rotate btom, and all its moves_with atoms, about atom so that the bond points to newdir.
+    void swing(SCoord newdir);		// Rotate atom2, and all its moves_with atoms, about atom so that the bond points to newdir.
 
 protected:
     void fill_moves_with_cache();
     void enforce_moves_with_uniqueness();
-    Atom** moves_with_btom = 0;
+    Atom** moves_with_atom2 = 0;
     Bond* reversed = nullptr;
 };
 
@@ -201,12 +201,12 @@ public:
     int get_count_pi_bonds();
     float get_sum_pi_bonds();
 
-    bool bond_to(Atom* btom, float cardinality);
-    void unbond(Atom* btom);
+    bool bond_to(Atom* atom2, float cardinality);
+    void unbond(Atom* atom2);
     void unbond_all();
     void consolidate_bonds();
 
-    float is_bonded_to(Atom* btom);			// If yes, return the cardinality.
+    float is_bonded_to(Atom* atom2);			// If yes, return the cardinality.
     Atom* is_bonded_to(const char* element);
     Atom* is_bonded_to(const char* element, const int cardinality);
     Atom* is_bonded_to(const int family);
@@ -216,15 +216,15 @@ public:
     int num_bonded_to(const char* element);
     int num_bonded_to_in_ring(const char* element, Ring* member_of);
 
-    bool shares_bonded_with(Atom* btom);
+    bool shares_bonded_with(Atom* atom2);
     bool check_Greek_continuity();
     Atom* get_heaviest_bonded_atom_that_isnt(Atom* excluded);
 
-    Bond* get_bond_between(Atom* btom);
+    Bond* get_bond_between(Atom* atom2);
     Bond* get_bond_between(const char* bname);
     Bond* get_bond_by_idx(int bidx);
     Bond* get_bond_closest_to(Point target);
-    int get_idx_bond_between(Atom* btom);
+    int get_idx_bond_between(Atom* atom2);
 
     float hydrophilicity_rule();
 
@@ -248,13 +248,13 @@ public:
             int i;
             for (i=0; i<geometry; i++)
             {
-                if (bonded_to[i].btom && in_same_ring_as(bonded_to[i].btom))
+                if (bonded_to[i].atom2 && in_same_ring_as(bonded_to[i].atom2))
                 {
                     if (bonded_to[i].cardinality > 1
                             ||
                             (	bonded_to[i].cardinality == 1
-                                && bonded_to[i].btom->get_Z() > 1
-                                && bonded_to[i].btom->get_bonded_atoms_count() < 4
+                                && bonded_to[i].atom2->get_Z() > 1
+                                && bonded_to[i].atom2->get_bonded_atoms_count() < 4
                             )
                     )
                     {
@@ -282,12 +282,12 @@ public:
     SCoord* get_geometry_aligned_to_bonds(bool prevent_infinite_loop = false);
     float get_geometric_bond_angle();
     float get_bond_angle_anomaly(SCoord v, Atom* ignore = nullptr);	// Assume v is centered on current atom.
-    float distance_to(Atom* btom)
+    float distance_to(Atom* atom2)
     {
-        if (!btom) return -1;
-        else return location.get_3d_distance(&btom->location);
+        if (!atom2) return -1;
+        else return location.get_3d_distance(&atom2->location);
     };
-    float similarity_to(Atom* btom);
+    float similarity_to(Atom* atom2);
     SCoord get_next_free_geometry(float lcard);
     int get_idx_next_free_geometry();
     void rotate_geometry(Rotation rot);			// Necessary for bond rotation.
@@ -325,7 +325,7 @@ public:
     bool is_backbone=false;			// "
     char* name;						// "
     bool used = false;      		// Required for certain algorithms such as Molecule::identify_rings().
-    int mirror_geo=-1;				// If >= 0, mirror the geometry of the btom of bonded_to[mirror_geo].
+    int mirror_geo=-1;				// If >= 0, mirror the geometry of the atom2 of bonded_to[mirror_geo].
     bool flip_mirror=false;			// If true, do trans rather than cis bond conformation.
     bool dnh=false;					// Do Not Hydrogenate. Used for bracketed atoms in SMILES conversion.
     bool EZ_flip = false;

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -39,8 +39,6 @@ class Atom;
 class Bond
 {
 public:
-    Atom* atom1 = 0;
-    Atom* atom2 = 0;
     float cardinality=0;			// aromatic bonds = 1.5.
     bool can_rotate=false;
     bool can_flip=false;
@@ -60,6 +58,18 @@ public:
     Bond(Atom* a, Atom* b, int card);
     ~Bond();
 
+    #if bond_reciprocity_fix
+    Atom* get_atom1();
+    Atom* get_atom2();
+    void set_atom1(Atom* a);
+    void set_atom2(Atom* a);
+    #else
+    inline Atom* get_atom1() { return atom1; }
+    inline Atom* get_atom2() { return atom2; }
+    inline void set_atom1(Atom* a) { atom1 = a; }
+    inline void set_atom2(Atom* a) { atom2 = a; }
+    #endif
+
     bool rotate(float angle_radians, bool allow_backbone = false, bool skip_inverse_check = false);
     Point ring_rotate(float angle_radians, Atom* stop_at);
     void clear_moves_with_cache()
@@ -74,6 +84,8 @@ public:
     void swing(SCoord newdir);		// Rotate atom2, and all its moves_with atoms, about atom so that the bond points to newdir.
 
 protected:
+    Atom* atom1 = nullptr;
+    Atom* atom2 = nullptr;
     void fill_moves_with_cache();
     void enforce_moves_with_uniqueness();
     Atom** moves_with_atom2 = 0;
@@ -248,13 +260,13 @@ public:
             int i;
             for (i=0; i<geometry; i++)
             {
-                if (bonded_to[i].atom2 && in_same_ring_as(bonded_to[i].atom2))
+                if (bonded_to[i].get_atom2() && in_same_ring_as(bonded_to[i].get_atom2()))
                 {
                     if (bonded_to[i].cardinality > 1
                             ||
                             (	bonded_to[i].cardinality == 1
-                                && bonded_to[i].atom2->get_Z() > 1
-                                && bonded_to[i].atom2->get_bonded_atoms_count() < 4
+                                && bonded_to[i].get_atom2()->get_Z() > 1
+                                && bonded_to[i].get_atom2()->get_bonded_atoms_count() < 4
                             )
                     )
                     {

--- a/src/classes/conj.cpp
+++ b/src/classes/conj.cpp
@@ -47,12 +47,12 @@ void Conjugation::add_atom(Atom* a, Atom* prev, Atom* orig)
 
     for (i=0; b[i]; i++)
     {
-        if (!b[i]->btom) continue;
-        if (!b[i]->btom->is_pi()) continue;
-        if (b[i]->btom == prev) continue;
-        if (b[i]->btom == orig) continue;
+        if (!b[i]->atom2) continue;
+        if (!b[i]->atom2->is_pi()) continue;
+        if (b[i]->atom2 == prev) continue;
+        if (b[i]->atom2 == orig) continue;
 
-        add_atom(b[i]->btom, a, orig);              // RECURSION!
+        add_atom(b[i]->atom2, a, orig);              // RECURSION!
     }
 }
 

--- a/src/classes/conj.cpp
+++ b/src/classes/conj.cpp
@@ -47,12 +47,12 @@ void Conjugation::add_atom(Atom* a, Atom* prev, Atom* orig)
 
     for (i=0; b[i]; i++)
     {
-        if (!b[i]->atom2) continue;
-        if (!b[i]->atom2->is_pi()) continue;
-        if (b[i]->atom2 == prev) continue;
-        if (b[i]->atom2 == orig) continue;
+        if (!b[i]->get_atom2()) continue;
+        if (!b[i]->get_atom2()->is_pi()) continue;
+        if (b[i]->get_atom2() == prev) continue;
+        if (b[i]->get_atom2() == orig) continue;
 
-        add_atom(b[i]->atom2, a, orig);              // RECURSION!
+        add_atom(b[i]->get_atom2(), a, orig);              // RECURSION!
     }
 }
 

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -405,6 +405,7 @@
 #define _DBG_STEPBYSTEP 0
 #define _DBG_TOOLARGE_DIFFNUMS 0
 #define _DBG_TUMBLE_SPHERES 0
+#define _dbg_unreciprocated_bonds 1
 #define _dbg_worst_energy 0
 #define _debug_active_bond_rot 0
 #define debug_stop_after_tumble_sphere 0

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -348,8 +348,8 @@
 // For auditing binding energies between individual atoms:
 #define _peratom_audit 0
 
-// A short-term feature that can be used to fix the bond reciprocity problem and then turned off to improve performance.
-#define bond_reciprocity_fix 1
+// A short-term feature that can be used in case the bond reciprocity problem recurs. See issue #423.
+#define bond_reciprocity_fix 0
 
 // Should normally be false or zero:
 #define _dbg_259 0
@@ -408,7 +408,7 @@
 #define _DBG_STEPBYSTEP 0
 #define _DBG_TOOLARGE_DIFFNUMS 0
 #define _DBG_TUMBLE_SPHERES 0
-#define _dbg_unreciprocated_bonds 1
+#define _dbg_unreciprocated_bonds 0
 #define _dbg_worst_energy 0
 #define _debug_active_bond_rot 0
 #define debug_stop_after_tumble_sphere 0

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -348,6 +348,9 @@
 // For auditing binding energies between individual atoms:
 #define _peratom_audit 0
 
+// A short-term feature that can be used to fix the bond reciprocity problem and then turned off to improve performance.
+#define bond_reciprocity_fix 1
+
 // Should normally be false or zero:
 #define _dbg_259 0
 #define _dbg_51e2_ionic 0

--- a/src/classes/group.cpp
+++ b/src/classes/group.cpp
@@ -460,9 +460,9 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                     matches[l*per_grp+j]->fetch_bonds(bonds);
                     for (m=0; bonds[m]; m++)
                     {
-                        if (!bonds[m]->atom2) continue;
-                        if (bonds[m]->atom2->get_Z() > 1) continue;
-                        k = mol->atom_idx_from_ptr(bonds[m]->atom2);
+                        if (!bonds[m]->get_atom2()) continue;
+                        if (bonds[m]->get_atom2()->get_Z() > 1) continue;
+                        k = mol->atom_idx_from_ptr(bonds[m]->get_atom2());
                         if (dirty[k])
                         {
                             any_dirty = true;
@@ -493,11 +493,11 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                     a->fetch_bonds(bonds);
                     for (m=0; bonds[m]; m++)
                     {
-                        if (!bonds[m]->atom2) continue;
-                        if (bonds[m]->atom2->get_Z() > 1) continue;
-                        k = mol->atom_idx_from_ptr(bonds[m]->atom2);
+                        if (!bonds[m]->get_atom2()) continue;
+                        if (bonds[m]->get_atom2()->get_Z() > 1) continue;
+                        k = mol->atom_idx_from_ptr(bonds[m]->get_atom2());
                         if (dirty[k]) continue;
-                        g->atoms.push_back(bonds[m]->atom2);
+                        g->atoms.push_back(bonds[m]->get_atom2());
                         dirty[k] = true;
                     }
                 }
@@ -563,16 +563,16 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                 int h, bbhidx;
                 for (h=0; bb[h]; h++)
                 {
-                    if (bb[h]->atom2 && bb[h]->atom2->get_Z() == 1)
+                    if (bb[h]->get_atom2() && bb[h]->get_atom2()->get_Z() == 1)
                     {
-                        bbhidx = mol->atom_idx_from_ptr(bb[h]->atom2);
+                        bbhidx = mol->atom_idx_from_ptr(bb[h]->get_atom2());
                         if (bbhidx >= 0 && !dirty[bbhidx])
                         {
-                            g->atoms.push_back(bb[h]->atom2);
+                            g->atoms.push_back(bb[h]->get_atom2());
                             dirty[bbhidx] = true;
 
                             #if _dbg_groupsel
-                            cout << "Adding " << bb[h]->atom2->name << "." << endl;
+                            cout << "Adding " << bb[h]->get_atom2()->name << "." << endl;
                             #endif
                         }
                     }
@@ -653,16 +653,16 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                                 int h, bbhidx;
                                 for (h=0; bb[h]; h++)
                                 {
-                                    if (bb[h]->atom2 && bb[h]->atom2->get_Z() == 1)
+                                    if (bb[h]->get_atom2() && bb[h]->get_atom2()->get_Z() == 1)
                                     {
-                                        bbhidx = mol->atom_idx_from_ptr(bb[h]->atom2);
+                                        bbhidx = mol->atom_idx_from_ptr(bb[h]->get_atom2());
                                         if (bbhidx >= 0 && !dirty[bbhidx])
                                         {
-                                            g->atoms.push_back(bb[h]->atom2);
+                                            g->atoms.push_back(bb[h]->get_atom2());
                                             dirty[bbhidx] = true;
 
                                             #if _dbg_groupsel
-                                            cout << "Adding " << bb[h]->atom2->name << "." << endl;
+                                            cout << "Adding " << bb[h]->get_atom2()->name << "." << endl;
                                             #endif
                                         }
                                     }
@@ -814,12 +814,12 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::make_hbond_subgroups(std::sha
             g->atoms[l]->fetch_bonds(lbb);
             for (j=0; lbb[j]; j++)
             {
-                if (lbb[j]->atom2 && lbb[j]->atom2->get_Z() == 1)
+                if (lbb[j]->get_atom2() && lbb[j]->get_atom2()->get_Z() == 1)
                 {
-                    g1->atoms.push_back(lbb[j]->atom2);
+                    g1->atoms.push_back(lbb[j]->get_atom2());
 
                     #if _dbg_groupsel
-                    cout << "Adding " << lbb[j]->atom2->name << "..." << endl;
+                    cout << "Adding " << lbb[j]->get_atom2()->name << "..." << endl;
                     #endif
                 }
             }

--- a/src/classes/group.cpp
+++ b/src/classes/group.cpp
@@ -460,9 +460,9 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                     matches[l*per_grp+j]->fetch_bonds(bonds);
                     for (m=0; bonds[m]; m++)
                     {
-                        if (!bonds[m]->btom) continue;
-                        if (bonds[m]->btom->get_Z() > 1) continue;
-                        k = mol->atom_idx_from_ptr(bonds[m]->btom);
+                        if (!bonds[m]->atom2) continue;
+                        if (bonds[m]->atom2->get_Z() > 1) continue;
+                        k = mol->atom_idx_from_ptr(bonds[m]->atom2);
                         if (dirty[k])
                         {
                             any_dirty = true;
@@ -493,11 +493,11 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                     a->fetch_bonds(bonds);
                     for (m=0; bonds[m]; m++)
                     {
-                        if (!bonds[m]->btom) continue;
-                        if (bonds[m]->btom->get_Z() > 1) continue;
-                        k = mol->atom_idx_from_ptr(bonds[m]->btom);
+                        if (!bonds[m]->atom2) continue;
+                        if (bonds[m]->atom2->get_Z() > 1) continue;
+                        k = mol->atom_idx_from_ptr(bonds[m]->atom2);
                         if (dirty[k]) continue;
-                        g->atoms.push_back(bonds[m]->btom);
+                        g->atoms.push_back(bonds[m]->atom2);
                         dirty[k] = true;
                     }
                 }
@@ -563,16 +563,16 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                 int h, bbhidx;
                 for (h=0; bb[h]; h++)
                 {
-                    if (bb[h]->btom && bb[h]->btom->get_Z() == 1)
+                    if (bb[h]->atom2 && bb[h]->atom2->get_Z() == 1)
                     {
-                        bbhidx = mol->atom_idx_from_ptr(bb[h]->btom);
+                        bbhidx = mol->atom_idx_from_ptr(bb[h]->atom2);
                         if (bbhidx >= 0 && !dirty[bbhidx])
                         {
-                            g->atoms.push_back(bb[h]->btom);
+                            g->atoms.push_back(bb[h]->atom2);
                             dirty[bbhidx] = true;
 
                             #if _dbg_groupsel
-                            cout << "Adding " << bb[h]->btom->name << "." << endl;
+                            cout << "Adding " << bb[h]->atom2->name << "." << endl;
                             #endif
                         }
                     }
@@ -653,16 +653,16 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::get_potential_ligand_groups(M
                                 int h, bbhidx;
                                 for (h=0; bb[h]; h++)
                                 {
-                                    if (bb[h]->btom && bb[h]->btom->get_Z() == 1)
+                                    if (bb[h]->atom2 && bb[h]->atom2->get_Z() == 1)
                                     {
-                                        bbhidx = mol->atom_idx_from_ptr(bb[h]->btom);
+                                        bbhidx = mol->atom_idx_from_ptr(bb[h]->atom2);
                                         if (bbhidx >= 0 && !dirty[bbhidx])
                                         {
-                                            g->atoms.push_back(bb[h]->btom);
+                                            g->atoms.push_back(bb[h]->atom2);
                                             dirty[bbhidx] = true;
 
                                             #if _dbg_groupsel
-                                            cout << "Adding " << bb[h]->btom->name << "." << endl;
+                                            cout << "Adding " << bb[h]->atom2->name << "." << endl;
                                             #endif
                                         }
                                     }
@@ -814,12 +814,12 @@ std::vector<std::shared_ptr<AtomGroup>> AtomGroup::make_hbond_subgroups(std::sha
             g->atoms[l]->fetch_bonds(lbb);
             for (j=0; lbb[j]; j++)
             {
-                if (lbb[j]->btom && lbb[j]->btom->get_Z() == 1)
+                if (lbb[j]->atom2 && lbb[j]->atom2->get_Z() == 1)
                 {
-                    g1->atoms.push_back(lbb[j]->btom);
+                    g1->atoms.push_back(lbb[j]->atom2);
 
                     #if _dbg_groupsel
-                    cout << "Adding " << lbb[j]->btom->name << "..." << endl;
+                    cout << "Adding " << lbb[j]->atom2->name << "..." << endl;
                     #endif
                 }
             }

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -376,7 +376,7 @@ void InteratomicForce::fetch_applicable(Atom* a, Atom* b, InteratomicForce** ret
             {
                 for (i=0; bb[i]; i++)
                 {
-                    if (bb[i]->atom2 != a && bb[i]->can_rotate)
+                    if (bb[i]->get_atom2() != a && bb[i]->can_rotate)
                     {
                         brot = bb[i];
                         H = a;
@@ -398,7 +398,7 @@ void InteratomicForce::fetch_applicable(Atom* a, Atom* b, InteratomicForce** ret
             {
                 for (i=0; bb[i]; i++)
                 {
-                    if (bb[i]->atom2 != b && bb[i]->can_rotate)
+                    if (bb[i]->get_atom2() != b && bb[i]->can_rotate)
                     {
                         brot = bb[i];
                         H = b;
@@ -625,13 +625,13 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
     if (aheavy->get_Z() == 1)
     {
         Bond* ab = a->get_bond_by_idx(0);
-        if (ab->atom2 && ab->atom2->get_Z() > 1) aheavy = ab->atom2;
+        if (ab->get_atom2() && ab->get_atom2()->get_Z() > 1) aheavy = ab->get_atom2();
     }
     Atom* bheavy = b;
     if (bheavy->get_Z() == 1)
     {
         Bond* bb = b->get_bond_by_idx(0);
-        if (bb->atom2 && bb->atom2->get_Z() > 1) bheavy = bb->atom2;
+        if (bb->get_atom2() && bb->get_atom2()->get_Z() > 1) bheavy = bb->get_atom2();
     }
     float rheavy = aheavy->distance_to(bheavy);
     float l_heavy_atom_mindist = aheavy->get_vdW_radius() + bheavy->get_vdW_radius();
@@ -667,31 +667,31 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
         if (a->get_Z() == 1)
         {
             Bond* prb = a->get_bond_by_idx(0);
-            if (prb && prb->atom2)
+            if (prb && prb->get_atom2())
             {
-                float prtheta = find_3d_angle(b->get_location(), prb->atom2->get_location(), a->get_location());
+                float prtheta = find_3d_angle(b->get_location(), prb->get_atom2()->get_location(), a->get_location());
                 pr *= 0.5 + 0.5 * cos(prtheta);
             }
         }
         else
         {
             Bond* sb = a->get_bond_closest_to(b->get_location());
-            if (sb && sb->atom2 && sb->atom2->distance_to(b) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
+            if (sb && sb->get_atom2() && sb->get_atom2()->distance_to(b) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
         }
 
         if (b->get_Z() == 1)
         {
             Bond* prb = b->get_bond_by_idx(0);
-            if (prb && prb->atom2)
+            if (prb && prb->get_atom2())
             {
-                float prtheta = find_3d_angle(a->get_location(), prb->atom2->get_location(), b->get_location());
+                float prtheta = find_3d_angle(a->get_location(), prb->get_atom2()->get_location(), b->get_location());
                 pr *= 0.5 + 0.5 * cos(prtheta);
             }
         }
         else
         {
             Bond* sb = b->get_bond_closest_to(a->get_location());
-            if (sb && sb->atom2 && sb->atom2->distance_to(a) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
+            if (sb && sb->get_atom2() && sb->get_atom2()->distance_to(a) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
         }
 
         kJmol -= pr;
@@ -925,14 +925,14 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
             {
                 avec[j] = ageo[j];
                 Bond* jb = a->get_bond_by_idx(j);
-                if (jb && jb->atom2) avec[j].r = 0;
+                if (jb && jb->get_atom2()) avec[j].r = 0;
             }
 
             for (j=0; j<bg; j++)
             {
                 bvec[j] = bgeo[j];
                 Bond* jb = b->get_bond_by_idx(j);
-                if (jb && jb->atom2) bvec[j].r = 0;
+                if (jb && jb->get_atom2()) bvec[j].r = 0;
             }
 
             #if _dbg_259
@@ -942,7 +942,7 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
                 {
                     cout << a->name << " vertex " << j;
                     Bond* b259 = a->get_bond_by_idx(j);
-                    if (b259 && b259->atom2) cout << " occupied by " << b259->atom2->name;
+                    if (b259 && b259->get_atom2()) cout << " occupied by " << b259->get_atom2()->name;
                     else cout << " vacant";
 
                     float th259 = find_3d_angle(aloc.add(ageo[j]), bloc, aloc);

--- a/src/classes/intera.cpp
+++ b/src/classes/intera.cpp
@@ -376,7 +376,7 @@ void InteratomicForce::fetch_applicable(Atom* a, Atom* b, InteratomicForce** ret
             {
                 for (i=0; bb[i]; i++)
                 {
-                    if (bb[i]->btom != a && bb[i]->can_rotate)
+                    if (bb[i]->atom2 != a && bb[i]->can_rotate)
                     {
                         brot = bb[i];
                         H = a;
@@ -398,7 +398,7 @@ void InteratomicForce::fetch_applicable(Atom* a, Atom* b, InteratomicForce** ret
             {
                 for (i=0; bb[i]; i++)
                 {
-                    if (bb[i]->btom != b && bb[i]->can_rotate)
+                    if (bb[i]->atom2 != b && bb[i]->can_rotate)
                     {
                         brot = bb[i];
                         H = b;
@@ -625,13 +625,13 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
     if (aheavy->get_Z() == 1)
     {
         Bond* ab = a->get_bond_by_idx(0);
-        if (ab->btom && ab->btom->get_Z() > 1) aheavy = ab->btom;
+        if (ab->atom2 && ab->atom2->get_Z() > 1) aheavy = ab->atom2;
     }
     Atom* bheavy = b;
     if (bheavy->get_Z() == 1)
     {
         Bond* bb = b->get_bond_by_idx(0);
-        if (bb->btom && bb->btom->get_Z() > 1) bheavy = bb->btom;
+        if (bb->atom2 && bb->atom2->get_Z() > 1) bheavy = bb->atom2;
     }
     float rheavy = aheavy->distance_to(bheavy);
     float l_heavy_atom_mindist = aheavy->get_vdW_radius() + bheavy->get_vdW_radius();
@@ -667,31 +667,31 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
         if (a->get_Z() == 1)
         {
             Bond* prb = a->get_bond_by_idx(0);
-            if (prb && prb->btom)
+            if (prb && prb->atom2)
             {
-                float prtheta = find_3d_angle(b->get_location(), prb->btom->get_location(), a->get_location());
+                float prtheta = find_3d_angle(b->get_location(), prb->atom2->get_location(), a->get_location());
                 pr *= 0.5 + 0.5 * cos(prtheta);
             }
         }
         else
         {
             Bond* sb = a->get_bond_closest_to(b->get_location());
-            if (sb && sb->btom && sb->btom->distance_to(b) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
+            if (sb && sb->atom2 && sb->atom2->distance_to(b) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
         }
 
         if (b->get_Z() == 1)
         {
             Bond* prb = b->get_bond_by_idx(0);
-            if (prb && prb->btom)
+            if (prb && prb->atom2)
             {
-                float prtheta = find_3d_angle(a->get_location(), prb->btom->get_location(), b->get_location());
+                float prtheta = find_3d_angle(a->get_location(), prb->atom2->get_location(), b->get_location());
                 pr *= 0.5 + 0.5 * cos(prtheta);
             }
         }
         else
         {
             Bond* sb = b->get_bond_closest_to(a->get_location());
-            if (sb && sb->btom && sb->btom->distance_to(a) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
+            if (sb && sb->atom2 && sb->atom2->distance_to(a) < (r - 0.5 * sb->optimal_radius) ) goto no_polar_repuls;
         }
 
         kJmol -= pr;
@@ -925,14 +925,14 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
             {
                 avec[j] = ageo[j];
                 Bond* jb = a->get_bond_by_idx(j);
-                if (jb && jb->btom) avec[j].r = 0;
+                if (jb && jb->atom2) avec[j].r = 0;
             }
 
             for (j=0; j<bg; j++)
             {
                 bvec[j] = bgeo[j];
                 Bond* jb = b->get_bond_by_idx(j);
-                if (jb && jb->btom) bvec[j].r = 0;
+                if (jb && jb->atom2) bvec[j].r = 0;
             }
 
             #if _dbg_259
@@ -942,7 +942,7 @@ float InteratomicForce::total_binding(Atom* a, Atom* b)
                 {
                     cout << a->name << " vertex " << j;
                     Bond* b259 = a->get_bond_by_idx(j);
-                    if (b259 && b259->btom) cout << " occupied by " << b259->btom->name;
+                    if (b259 && b259->atom2) cout << " occupied by " << b259->atom2->name;
                     else cout << " vacant";
 
                     float th259 = find_3d_angle(aloc.add(ageo[j]), bloc, aloc);

--- a/src/classes/moiety.cpp
+++ b/src/classes/moiety.cpp
@@ -212,44 +212,44 @@ int Moiety::does_atom_match(Atom* a, Atom** out_matches)
             for (j=0; j<bn; j++)
             {
                 if (!b[j]) continue;
-                if (!b[j]->atom2) continue;
-                if (b[j]->atom2->used)
+                if (!b[j]->get_atom2()) continue;
+                if (b[j]->get_atom2()->used)
                 {
                     #if _dbg_moieties
-                    cout << "Skipping " << b[j]->atom2->name << " as 'used'..." << endl;
+                    cout << "Skipping " << b[j]->get_atom2()->name << " as 'used'..." << endl;
                     #endif
                     continue;
                 }
                 bool used = false;
-                for (l=0; l<atoms_used; l++) if (out_matches[l] == b[j]->atom2)
+                for (l=0; l<atoms_used; l++) if (out_matches[l] == b[j]->get_atom2())
                 {
                     #if _dbg_moieties
-                    cout << "Skipping " << b[j]->atom2->name << " already matched..." << endl;
+                    cout << "Skipping " << b[j]->get_atom2()->name << " already matched..." << endl;
                     #endif
                     used = true;
                 }
-                for (l=0; l<num_duds; l++) if (dud_atoms[l] == b[j]->atom2)
+                for (l=0; l<num_duds; l++) if (dud_atoms[l] == b[j]->get_atom2())
                 {
                     #if _dbg_moieties
-                    cout << "Skipping " << b[j]->atom2->name << " as a 'dud'..." << endl;
+                    cout << "Skipping " << b[j]->get_atom2()->name << " as a 'dud'..." << endl;
                     #endif
                     used = true;
                 }
                 if (used) continue;
                 #if _dbg_moieties
-                cout << "Trying " << *cursor[parens] << "~" << *(b[j]->atom2) << " for " << buffer << "..." << endl;
+                cout << "Trying " << *cursor[parens] << "~" << *(b[j]->get_atom2()) << " for " << buffer << "..." << endl;
                 #endif
-                if (atom_matches_string(b[j]->atom2, buffer))
+                if (atom_matches_string(b[j]->get_atom2(), buffer))
                 {
                     if (card)
                     {
-                        Bond* between = cursor[parens]->get_bond_between(b[j]->atom2);
+                        Bond* between = cursor[parens]->get_bond_between(b[j]->get_atom2());
                         int lcard = between->cardinality;
                         if (between->cardinality > 1 && between->cardinality < 2 && card >= 1 && card <= 2) lcard = card;
                         if (lcard != card)
                         {
                             #if _dbg_moieties
-                            cout << "Skipping " << b[j]->atom2->name << " for bond cardinality..." << endl;
+                            cout << "Skipping " << b[j]->get_atom2()->name << " for bond cardinality..." << endl;
                             #endif
                             continue;
                         }
@@ -257,15 +257,15 @@ int Moiety::does_atom_match(Atom* a, Atom** out_matches)
                     }
                     found = true;
                     #if _dbg_moieties
-                    cout << "Matched " << b[j]->atom2->name << endl;
+                    cout << "Matched " << b[j]->get_atom2()->name << endl;
                     #endif
-                    cursor[parens] = b[j]->atom2;
-                    out_matches[atoms_used++] = b[j]->atom2;
-                    b[j]->atom2->used = true;
+                    cursor[parens] = b[j]->get_atom2();
+                    out_matches[atoms_used++] = b[j]->get_atom2();
+                    b[j]->get_atom2()->used = true;
                     break;
                 }
                 #if _dbg_moieties
-                cout << b[j]->atom2->name << " did not match " << buffer << "." << endl;
+                cout << b[j]->get_atom2()->name << " did not match " << buffer << "." << endl;
                 #endif
             }
             if (!found)

--- a/src/classes/moiety.cpp
+++ b/src/classes/moiety.cpp
@@ -212,44 +212,44 @@ int Moiety::does_atom_match(Atom* a, Atom** out_matches)
             for (j=0; j<bn; j++)
             {
                 if (!b[j]) continue;
-                if (!b[j]->btom) continue;
-                if (b[j]->btom->used)
+                if (!b[j]->atom2) continue;
+                if (b[j]->atom2->used)
                 {
                     #if _dbg_moieties
-                    cout << "Skipping " << b[j]->btom->name << " as 'used'..." << endl;
+                    cout << "Skipping " << b[j]->atom2->name << " as 'used'..." << endl;
                     #endif
                     continue;
                 }
                 bool used = false;
-                for (l=0; l<atoms_used; l++) if (out_matches[l] == b[j]->btom)
+                for (l=0; l<atoms_used; l++) if (out_matches[l] == b[j]->atom2)
                 {
                     #if _dbg_moieties
-                    cout << "Skipping " << b[j]->btom->name << " already matched..." << endl;
+                    cout << "Skipping " << b[j]->atom2->name << " already matched..." << endl;
                     #endif
                     used = true;
                 }
-                for (l=0; l<num_duds; l++) if (dud_atoms[l] == b[j]->btom)
+                for (l=0; l<num_duds; l++) if (dud_atoms[l] == b[j]->atom2)
                 {
                     #if _dbg_moieties
-                    cout << "Skipping " << b[j]->btom->name << " as a 'dud'..." << endl;
+                    cout << "Skipping " << b[j]->atom2->name << " as a 'dud'..." << endl;
                     #endif
                     used = true;
                 }
                 if (used) continue;
                 #if _dbg_moieties
-                cout << "Trying " << *cursor[parens] << "~" << *(b[j]->btom) << " for " << buffer << "..." << endl;
+                cout << "Trying " << *cursor[parens] << "~" << *(b[j]->atom2) << " for " << buffer << "..." << endl;
                 #endif
-                if (atom_matches_string(b[j]->btom, buffer))
+                if (atom_matches_string(b[j]->atom2, buffer))
                 {
                     if (card)
                     {
-                        Bond* between = cursor[parens]->get_bond_between(b[j]->btom);
+                        Bond* between = cursor[parens]->get_bond_between(b[j]->atom2);
                         int lcard = between->cardinality;
                         if (between->cardinality > 1 && between->cardinality < 2 && card >= 1 && card <= 2) lcard = card;
                         if (lcard != card)
                         {
                             #if _dbg_moieties
-                            cout << "Skipping " << b[j]->btom->name << " for bond cardinality..." << endl;
+                            cout << "Skipping " << b[j]->atom2->name << " for bond cardinality..." << endl;
                             #endif
                             continue;
                         }
@@ -257,15 +257,15 @@ int Moiety::does_atom_match(Atom* a, Atom** out_matches)
                     }
                     found = true;
                     #if _dbg_moieties
-                    cout << "Matched " << b[j]->btom->name << endl;
+                    cout << "Matched " << b[j]->atom2->name << endl;
                     #endif
-                    cursor[parens] = b[j]->btom;
-                    out_matches[atoms_used++] = b[j]->btom;
-                    b[j]->btom->used = true;
+                    cursor[parens] = b[j]->atom2;
+                    out_matches[atoms_used++] = b[j]->atom2;
+                    b[j]->atom2->used = true;
                     break;
                 }
                 #if _dbg_moieties
-                cout << b[j]->btom->name << " did not match " << buffer << "." << endl;
+                cout << b[j]->atom2->name << " did not match " << buffer << "." << endl;
                 #endif
             }
             if (!found)

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -462,7 +462,7 @@ void Molecule::hydrogenate(bool steric_only)
         {
             for (j=0; aib[j]; j++)
             {
-                if (aib[j]->btom) bcardsum += aib[j]->cardinality;
+                if (aib[j]->atom2) bcardsum += aib[j]->cardinality;
                 if (aib[j]->cardinality > 1) db++;
             }
         }
@@ -507,23 +507,23 @@ void Molecule::hydrogenate(bool steric_only)
             if (atoms[i]->get_geometry() == 3)
             {
                 Bond* aib = atoms[i]->get_bond_by_idx(1);
-                if (1) // aib && aib->total_rotations) // aib->btom == H)
+                if (1) // aib && aib->total_rotations) // aib->atom2 == H)
                 {
                     /*Bond* b0 = atoms[i]->get_bond_by_idx(0);
                     Bond* b1 = atoms[i]->get_bond_by_idx(1);
-                    if (!b1 || !b1->btom) b1 = atoms[i]->get_bond_by_idx(2);*/
+                    if (!b1 || !b1->atom2) b1 = atoms[i]->get_bond_by_idx(2);*/
 
                     int k=0;
                     Bond* b0 = atoms[i]->get_bond_by_idx(k++);
-                    if (!b0->btom || b0->btom == H) b0 = atoms[i]->get_bond_by_idx(k++);
+                    if (!b0->atom2 || b0->atom2 == H) b0 = atoms[i]->get_bond_by_idx(k++);
                     Bond* b1 = atoms[i]->get_bond_by_idx(k++);
-                    if (!b1->btom || b1->btom == H) b1 = atoms[i]->get_bond_by_idx(k++);
+                    if (!b1->atom2 || b1->atom2 == H) b1 = atoms[i]->get_bond_by_idx(k++);
 
-                    if (b0->btom && b1->btom && (abs((__int64_t)(b1) - (__int64_t)b1->btom) < memsanity))
+                    if (b0->atom2 && b1->atom2 && (abs((__int64_t)(b1) - (__int64_t)b1->atom2) < memsanity))
                     {
                         Point source = atoms[i]->get_location();
-                        /*Point axis = b0->btom->get_location();
-                        Point avoid = b1->btom->get_location();
+                        /*Point axis = b0->atom2->get_location();
+                        Point avoid = b1->atom2->get_location();
                         Point movable = H->get_location();
                         SCoord v(axis.subtract(source));
 
@@ -533,15 +533,15 @@ void Molecule::hydrogenate(bool steric_only)
 
                         if (r_is < r_wouldbe) H->move(visibly_moved);*/
 
-                        Point movable = b1->btom->get_location();
+                        Point movable = b1->atom2->get_location();
                         /*cout << "Getting normal of " << atoms[i]->name << " - "
-                        	 << b0->btom->name << " - " << b1->btom->name << endl;*/
-                        SCoord axis = compute_normal(source, b0->btom->get_location(), b1->btom->get_location());
+                        	 << b0->atom2->name << " - " << b1->atom2->name << endl;*/
+                        SCoord axis = compute_normal(source, b0->atom2->get_location(), b1->atom2->get_location());
                         Point plus  = rotate3D(movable, source, axis,  triangular);
                         Point minus = rotate3D(movable, source, axis, -triangular);
 
-                        float rp = plus.get_3d_distance(b0->btom->get_location());
-                        float rm = minus.get_3d_distance(b0->btom->get_location());
+                        float rp = plus.get_3d_distance(b0->atom2->get_location());
+                        float rm = minus.get_3d_distance(b0->atom2->get_location());
 
                         Point pt = ((rp > rm) ? plus : minus).subtract(source);
                         pt.scale(InteratomicForce::covalent_bond_radius(atoms[i], H, 1));
@@ -680,30 +680,30 @@ float Molecule::total_eclipses()
             if (!abt[j]) continue;
             if (abt[j]->cardinality > 1) continue;
             if (!abt[j]->can_rotate) continue;
-            if (!abt[j]->btom) continue;
-            if (abt[j]->btom->get_Z() < 2) continue;
-            if (atoms[i]->is_pi() && abt[j]->btom->is_pi()) continue;
-            if (atoms[i]->is_backbone && abt[j]->btom->is_backbone) continue;
-            SCoord axis = abt[j]->btom->get_location().subtract(atoms[i]->get_location());
+            if (!abt[j]->atom2) continue;
+            if (abt[j]->atom2->get_Z() < 2) continue;
+            if (atoms[i]->is_pi() && abt[j]->atom2->is_pi()) continue;
+            if (atoms[i]->is_backbone && abt[j]->atom2->is_backbone) continue;
+            SCoord axis = abt[j]->atom2->get_location().subtract(atoms[i]->get_location());
             Bond* bbt[16];
-            abt[j]->btom->fetch_bonds(bbt);
-            m = abt[j]->btom->get_geometry();
+            abt[j]->atom2->fetch_bonds(bbt);
+            m = abt[j]->atom2->get_geometry();
             for (k=0; k<m; k++)
             {
                 if (!bbt[k]) continue;
-                if (!bbt[k]->btom) continue;
-                if (bbt[k]->btom == atoms[i]) continue;
+                if (!bbt[k]->atom2) continue;
+                if (bbt[k]->atom2 == atoms[i]) continue;
                 for (l=0; l<n; l++)
                 {
                     if (l == j) continue;
                     if (!abt[l]) continue;
-                    if (!abt[l]->btom) continue;
-                    float theta = find_angle_along_vector(bbt[k]->btom->get_location(), abt[l]->btom->get_location(), atoms[i]->get_location(), axis);
+                    if (!abt[l]->atom2) continue;
+                    float theta = find_angle_along_vector(bbt[k]->atom2->get_location(), abt[l]->atom2->get_location(), atoms[i]->get_location(), axis);
                     if (theta >= -hexagonal && theta <= hexagonal)
                     {
                         #if _dbg_eclipses
-                        cout << bbt[k]->btom->name << " is " << (theta*fiftyseven) << "deg from " << abt[l]->btom->name
-                            << " along the " << atoms[i]->name << " - " << abt[j]->btom->name << " axis."
+                        cout << bbt[k]->atom2->name << " is " << (theta*fiftyseven) << "deg from " << abt[l]->atom2->name
+                            << " along the " << atoms[i]->name << " - " << abt[j]->atom2->name << " axis."
                             << endl;
                         #endif
                         theta = hexagonal - fabs(theta);
@@ -958,7 +958,7 @@ bool Molecule::check_Greek_continuity()
                 {
                     Atom* mwb[256];
                     for (l=0; l<256; l++) mwb[l] = nullptr;
-                    bb[k]->fetch_moves_with_btom(mwb);
+                    bb[k]->fetch_moves_with_atom2(mwb);
                     for (l=0; mwb[l]; l++)
                     {
                         if (mwb[l] == atoms[j])
@@ -1080,7 +1080,7 @@ int Molecule::get_bond_count(bool unidirectional) const
 
         for (j=0; b[j]; j++)
         {
-            if (b[j]->btom > atoms[i] || !unidirectional) bc++;
+            if (b[j]->atom2 > atoms[i] || !unidirectional) bc++;
         }
     }
 
@@ -1203,8 +1203,8 @@ bool Molecule::save_sdf(FILE* os, Molecule** lig)
 
         for (j=0; j<ac; j++)
         {
-            if (latoms[j] == lbonds[i]->atom) laidx = j+1;
-            if (latoms[j] == lbonds[i]->btom) lbidx = j+1;
+            if (latoms[j] == lbonds[i]->atom1) laidx = j+1;
+            if (latoms[j] == lbonds[i]->atom2) lbidx = j+1;
         }
 
         // fprintf(os, " %d %d  %d  0  0  0  0\n", laidx, lbidx, (int)lbonds[i]->cardinality);
@@ -1477,13 +1477,13 @@ void Molecule::find_paths()
     n=0;
     for (i=0; b[i]; i++)
     {
-        if (!b[i]->btom) continue;
-        if (b[i]->btom->get_Z() < 2) continue;
-        if (b[i]->btom->residue && b[i]->btom->residue != a->residue) continue;
+        if (!b[i]->atom2) continue;
+        if (b[i]->atom2->get_Z() < 2) continue;
+        if (b[i]->atom2->residue && b[i]->atom2->residue != a->residue) continue;
         paths[n] = new Atom*[atcount];
         for (q=0; q<atcount; q++) paths[n][q] = nullptr;
         paths[n][0] = a;
-        paths[n][1] = b[i]->btom;
+        paths[n][1] = b[i]->atom2;
         paths[n][2] = nullptr;
         n++;
     }
@@ -1508,17 +1508,17 @@ void Molecule::find_paths()
             for (j=0; b[j]; j++)
             {
                 if (abs((__int64_t)(a) - (__int64_t)b[j]) > memsanity) break;
-                if (abs((__int64_t)(b[j]) - (__int64_t)b[j]->btom) > memsanity) break;
-                if (!b[j]->btom) continue;
-                if (b[j]->btom->get_Z() < 2) continue;
-                if (b[j]->btom->get_bonded_heavy_atoms_count() < 2) continue;
-                if (b[j]->btom->residue && b[j]->btom->residue != a->residue) continue;
+                if (abs((__int64_t)(b[j]) - (__int64_t)b[j]->atom2) > memsanity) break;
+                if (!b[j]->atom2) continue;
+                if (b[j]->atom2->get_Z() < 2) continue;
+                if (b[j]->atom2->get_bonded_heavy_atoms_count() < 2) continue;
+                if (b[j]->atom2->residue && b[j]->atom2->residue != a->residue) continue;
 
                 #if _dbg_path_search
-                cout << "Trying " << b[j]->btom->name << "... ";
+                cout << "Trying " << b[j]->atom2->name << "... ";
                 #endif
 
-                l = path_contains_atom(i, b[j]->btom);
+                l = path_contains_atom(i, b[j]->atom2);
                 if (l > 0)
                 {
                     if ((m-l) > 1)
@@ -1528,7 +1528,7 @@ void Molecule::find_paths()
                         {
                             ring_atoms[h-l] = paths[i][h];
                         }
-                        ring_atoms[h-l] = b[j]->btom;
+                        ring_atoms[h-l] = b[j]->atom2;
                         h++;
                         ring_atoms[h-l] = nullptr;
 
@@ -1545,7 +1545,7 @@ void Molecule::find_paths()
                     paths[n] = new Atom*[atcount];
                     for (q=0; q<atcount; q++) paths[n][q] = nullptr;
                     copy_path(i, n);
-                    paths[n][m] = b[j]->btom;
+                    paths[n][m] = b[j]->atom2;
                     paths[n][m+1] = nullptr;
 
                     #if _dbg_path_search
@@ -1638,9 +1638,9 @@ void Molecule::identify_acidbase()
                     for (j=0; j<nb2; j++)
                     {
                         if (!b[j]) break;
-                        if (!b[j]->btom) break;
-                        if (!b[j]->btom->get_Z()) break;
-                        planarity_check[l++] = b[j]->btom->get_location();
+                        if (!b[j]->atom2) break;
+                        if (!b[j]->atom2->get_Z()) break;
+                        planarity_check[l++] = b[j]->atom2->get_location();
                     }
 
                     bool lplanar = false;
@@ -1665,20 +1665,20 @@ void Molecule::identify_acidbase()
                         for (j=0; j<l; j++)
                         {
                             if (!b[j]) break;
-                            if (!b[j]->btom) break;
-                            if (!b[j]->btom->get_Z()) break;
-                            int bfam = b[j]->btom->get_family();
+                            if (!b[j]->atom2) break;
+                            if (!b[j]->atom2->get_Z()) break;
+                            int bfam = b[j]->atom2->get_family();
                             if (bfam == PNICTOGEN || bfam == CHALCOGEN)
                             {
-                                b[j]->btom->aromatize();
+                                b[j]->atom2->aromatize();
                                 b[j]->cardinality = 1.5;
 
-                                if (bfam == CHALCOGEN && b[j]->btom->get_bonded_heavy_atoms_count() < 2)
+                                if (bfam == CHALCOGEN && b[j]->atom2->get_bonded_heavy_atoms_count() < 2)
                                 {
                                     chalcogens++;
-                                    if (chalcogens > 1 && !b[j]->btom->get_charge())
+                                    if (chalcogens > 1 && !b[j]->atom2->get_charge())
                                     {
-                                        b[j]->btom->increment_charge(-1);
+                                        b[j]->atom2->increment_charge(-1);
                                         chalcogens = -65536;
                                     }
                                 }
@@ -1696,10 +1696,10 @@ void Molecule::identify_acidbase()
                 }
                 for (j=0; b[j]; j++)
                 {
-                    if (!b[j]->btom) continue;
+                    if (!b[j]->atom2) continue;
                     if (b[j]->cardinality == 2)
                     {
-                        int fam = b[j]->btom->get_family();
+                        int fam = b[j]->atom2->get_family();
                         if (fam != CHALCOGEN)
                         {
                             goto _not_acidic;
@@ -1709,8 +1709,8 @@ void Molecule::identify_acidbase()
             }
             for (j=0; b[j]; j++)
             {
-                if (!b[j]->btom) continue;
-                int fam = b[j]->btom->get_family();
+                if (!b[j]->atom2) continue;
+                int fam = b[j]->atom2->get_family();
                 if (carbon && fam == PNICTOGEN)
                 {
                     goto _not_acidic;
@@ -1718,7 +1718,7 @@ void Molecule::identify_acidbase()
                 //cout << "Fam: " << fam << endl;
                 if (fam == CHALCOGEN && b[j]->cardinality < 2)
                 {
-                    if (b[j]->btom->get_charge() < 0)
+                    if (b[j]->atom2->get_charge() < 0)
                     {
                         sbOH++;
                         break;
@@ -1726,15 +1726,15 @@ void Molecule::identify_acidbase()
                     else
                     {
                         Bond* b1[16];
-                        b[j]->btom->fetch_bonds(b1);
+                        b[j]->atom2->fetch_bonds(b1);
                         if (!b1[0])
                         {
                             goto _not_acidic;
                         }
                         for (k=0; b1[k]; k++)
                         {
-                            if (!b1[k]->btom) continue;
-                            if (b1[k]->btom->get_Z() == 1)
+                            if (!b1[k]->atom2) continue;
+                            if (b1[k]->atom2->get_Z() == 1)
                             {
                                 sbOH++;
                                 //cout << "OH" << endl;
@@ -1750,12 +1750,12 @@ void Molecule::identify_acidbase()
             atoms[i]->fetch_bonds(b);
             for (j=0; b[j]; j++)
             {
-                if (!b[j]->btom) continue;
-                int fam = b[j]->btom->get_family();
+                if (!b[j]->atom2) continue;
+                int fam = b[j]->atom2->get_family();
                 if (fam == CHALCOGEN)
                 {
-                    b[j]->btom->set_acidbase(-1);
-                    //cout << "Atom " << b[j]->btom->name << " is acidic." << endl;
+                    b[j]->atom2->set_acidbase(-1);
+                    //cout << "Atom " << b[j]->atom2->name << " is acidic." << endl;
                 }
             }
         }
@@ -1814,8 +1814,8 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
         Star s;
         s.pmol = this;
         if (!rotatable_bonds) rotatable_bonds = s.paa->get_rotatable_bonds();
-        else if (rotatable_bonds[0] && rotatable_bonds[1] && rotatable_bonds[0]->atom == rotatable_bonds[1]->atom) rotatable_bonds = s.paa->get_rotatable_bonds();
-        else if (rotatable_bonds[0] && abs(rotatable_bonds[0]->atom - rotatable_bonds[0]->btom) >= 524288) rotatable_bonds = s.paa->get_rotatable_bonds();
+        else if (rotatable_bonds[0] && rotatable_bonds[1] && rotatable_bonds[0]->atom1 == rotatable_bonds[1]->atom1) rotatable_bonds = s.paa->get_rotatable_bonds();
+        else if (rotatable_bonds[0] && abs(rotatable_bonds[0]->atom1 - rotatable_bonds[0]->atom2) >= 524288) rotatable_bonds = s.paa->get_rotatable_bonds();
         return rotatable_bonds;
     }
     // cout << name << " Molecule::get_rotatable_bonds()" << endl << flush;
@@ -1832,18 +1832,18 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
             int g = atoms[i]->get_geometry();
             for (j=0; j<g && lb[j]; j++)
             {
-                if (!lb[j]->atom || !lb[j]->btom) continue;
+                if (!lb[j]->atom1 || !lb[j]->atom2) continue;
 
-                if (lb[j]->cardinality > 1 && (!lb[j]->atom->is_pi() || !lb[j]->btom->is_pi()) && lb[j]->cardinality < 3)
+                if (lb[j]->cardinality > 1 && (!lb[j]->atom1->is_pi() || !lb[j]->atom2->is_pi()) && lb[j]->cardinality < 3)
                     lb[j]->cardinality = 1;
 
-                bool pia = lb[j]->atom->is_pi(),
-                     pib = lb[j]->btom->is_pi();
+                bool pia = lb[j]->atom1->is_pi(),
+                     pib = lb[j]->atom2->is_pi();
 
-                int fa = lb[j]->atom->get_family(),
-                    fb = lb[j]->btom->get_family();
+                int fa = lb[j]->atom1->get_family(),
+                    fb = lb[j]->atom2->get_family();
 
-                if (lb[j]->atom->in_same_ring_as(lb[j]->btom))
+                if (lb[j]->atom1->in_same_ring_as(lb[j]->atom2))
                 {
                     #if _ALLOW_FLEX_RINGS
                     lb[j]->can_flip = !lb[j]->caged && (lb[j]->cardinality == 1);
@@ -1863,23 +1863,23 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
                     lb[j]->can_rotate = false;
                     if ((fa == CHALCOGEN || fb == CHALCOGEN)
                         && fa != fb
-                        && lb[j]->btom->get_bonded_atoms_count() > 1
+                        && lb[j]->atom2->get_bonded_atoms_count() > 1
                         ) lb[j]->can_flip = !lb[j]->caged;
                 }
 
                 // If atoms a and b are pi, and a-b cannot rotate, then a-b can flip.
                 if (!lb[j]->can_rotate
-                    && lb[j]->btom->is_bonded_to(CHALCOGEN)
+                    && lb[j]->atom2->is_bonded_to(CHALCOGEN)
                     && fa != CHALCOGEN
-                    && !(lb[j]->atom->in_same_ring_as(lb[j]->btom))
+                    && !(lb[j]->atom1->in_same_ring_as(lb[j]->atom2))
                     )
                 {
                     lb[j]->can_flip = !lb[j]->caged;
                 }
 
-                if (lb[j]->btom
+                if (lb[j]->atom2
                         &&
-                        lb[j]->atom < lb[j]->btom
+                        lb[j]->atom1 < lb[j]->atom2
                         &&
                         (lb[j]->can_rotate || (icf && lb[j]->can_flip))
                    )
@@ -1899,35 +1899,35 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
             {
                 // Generally, a single bond between pi atoms cannot rotate.
                 // Same if pi atom bonded to a pnictogen or chalcogen without a single bond to other atoms.
-                if (lb[j]->atom && lb[j]->btom
+                if (lb[j]->atom1 && lb[j]->atom2
                     &&  (
                             (
-                                lb[j]->atom->is_pi() &&
-                                (   lb[j]->btom->is_pi()
+                                lb[j]->atom1->is_pi() &&
+                                (   lb[j]->atom2->is_pi()
                                     ||
                                     (   
-                                        !lb[j]->btom->is_bonded_to_pi(TETREL, false)
+                                        !lb[j]->atom2->is_bonded_to_pi(TETREL, false)
                                         &&
                                         (
-                                            lb[j]->btom->get_family() == PNICTOGEN
+                                            lb[j]->atom2->get_family() == PNICTOGEN
                                             ||
-                                            lb[j]->btom->get_family() == CHALCOGEN
+                                            lb[j]->atom2->get_family() == CHALCOGEN
                                         )
                                     )
                                 )
                             )
                             ||
                             (
-                                lb[j]->btom->is_pi() &&
-                                (   lb[j]->atom->is_pi()
+                                lb[j]->atom2->is_pi() &&
+                                (   lb[j]->atom1->is_pi()
                                     ||
                                     (   
-                                        !lb[j]->atom->is_bonded_to_pi(TETREL, false)
+                                        !lb[j]->atom1->is_bonded_to_pi(TETREL, false)
                                         &&
                                         (
-                                            lb[j]->atom->get_family() == PNICTOGEN
+                                            lb[j]->atom1->get_family() == PNICTOGEN
                                             ||
-                                            lb[j]->atom->get_family() == CHALCOGEN
+                                            lb[j]->atom1->get_family() == CHALCOGEN
                                         )
                                     )
                                 )
@@ -1938,15 +1938,15 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
 
                 if ((lb[j]->can_rotate || (icf && lb[j]->can_flip))
                         &&
-                        lb[j]->atom && lb[j]->btom
+                        lb[j]->atom1 && lb[j]->atom2
                         &&
-                        (!lb[j]->atom->is_backbone || !strcmp(lb[j]->atom->name, "CA"))
+                        (!lb[j]->atom1->is_backbone || !strcmp(lb[j]->atom1->name, "CA"))
                         &&
-                        !lb[j]->btom->is_backbone
+                        !lb[j]->atom2->is_backbone
                         &&
-                        greek_from_aname(lb[j]->atom->name) == (greek_from_aname(lb[j]->btom->name)-1)
+                        greek_from_aname(lb[j]->atom1->name) == (greek_from_aname(lb[j]->atom2->name)-1)
                         &&
-                        lb[j]->btom->get_Z() > 1
+                        lb[j]->atom2->get_Z() > 1
                    )
                 {
                     btemp[bonds++] = lb[j];
@@ -2055,10 +2055,10 @@ Bond** AminoAcid::get_rotatable_bonds()
                             for (o=0; o<ag; o++)
                                 if (lbb[o]
                                     && (abs((__int64_t)(this) - (__int64_t)lbb[o]) < memsanity)
-                                    && lbb[o]->btom
-                                    && (abs((__int64_t)(this) - (__int64_t)lbb[o]->btom) < memsanity)
+                                    && lbb[o]->atom2
+                                    && (abs((__int64_t)(this) - (__int64_t)lbb[o]->atom2) < memsanity)
                                     )
-                                    cout << " " << lbb[o]->btom->name;
+                                    cout << " " << lbb[o]->atom2->name;
                             cout << "." << endl;
                         }
 
@@ -2070,7 +2070,7 @@ Bond** AminoAcid::get_rotatable_bonds()
                             {
                                 cout << lba->name << " is bonded to:";
                                 int o, ag = lba->get_geometry();
-                                for (o=0; o<ag; o++) if (lbb[o]->btom) cout << " " << lbb[o]->btom->name;
+                                for (o=0; o<ag; o++) if (lbb[o]->atom2) cout << " " << lbb[o]->atom2->name;
                                 cout << "." << endl;
                             }
                         }
@@ -2080,7 +2080,7 @@ Bond** AminoAcid::get_rotatable_bonds()
                     {
                         // cout << (name ? name : "(no name)") << ":" << *(lb) << endl;
                         // Generally, a single bond between pi atoms cannot rotate.
-                        if (lb->atom->is_pi() && lb->btom && lb->btom->is_pi())
+                        if (lb->atom1->is_pi() && lb->atom2 && lb->atom2->is_pi())
                         {
                             lb->can_rotate = false;
                             lb->can_flip = !lb->caged;
@@ -2093,18 +2093,18 @@ Bond** AminoAcid::get_rotatable_bonds()
                                 &&
                                 la->get_Z() > 1
                                 &&
-                                (	greek_from_aname(la->name) == (greek_from_aname(lb->btom->name)+1)
+                                (	greek_from_aname(la->name) == (greek_from_aname(lb->atom2->name)+1)
                                     ||
-                                    greek_from_aname(la->name) == (greek_from_aname(lb->btom->name)-1)
+                                    greek_from_aname(la->name) == (greek_from_aname(lb->atom2->name)-1)
                                 )
                            )
                         {
                             // cout << "Included." << endl;
 
-                            if (greek_from_aname(la->name) < greek_from_aname(lb->btom->name))
-                                btemp[bonds] = la->get_bond_between(lb->btom);
+                            if (greek_from_aname(la->name) < greek_from_aname(lb->atom2->name))
+                                btemp[bonds] = la->get_bond_between(lb->atom2);
                             else
-                                btemp[bonds] = lb->btom->get_bond_between(la);
+                                btemp[bonds] = lb->atom2->get_bond_between(la);
 
                             btemp[++bonds] = 0;
 
@@ -2129,15 +2129,15 @@ Bond** AminoAcid::get_rotatable_bonds()
             if (!lb[j]) break;
             if (lb[j]->can_rotate
                     &&
-                    lb[j]->atom && lb[j]->btom
+                    lb[j]->atom1 && lb[j]->atom2
                     &&
-                    (!lb[j]->atom->is_backbone || !strcmp(lb[j]->atom->name, "CA"))
+                    (!lb[j]->atom1->is_backbone || !strcmp(lb[j]->atom1->name, "CA"))
                     &&
-                    !lb[j]->btom->is_backbone
+                    !lb[j]->atom2->is_backbone
                     &&
-                    greek_from_aname(lb[j]->atom->name) == (greek_from_aname(lb[j]->btom->name)-1)
+                    greek_from_aname(lb[j]->atom1->name) == (greek_from_aname(lb[j]->atom2->name)-1)
                     &&
-                    lb[j]->btom->get_Z() > 1
+                    lb[j]->atom2->get_Z() > 1
                )
             {
                 // cout << *lb[j] << " ";
@@ -2187,7 +2187,7 @@ Bond** Molecule::get_all_bonds(bool unidirectional)
         for (j=0; j<g; j++)
         {
             if (!lb[j]) break;
-            if (lb[j]->atom < lb[j]->btom
+            if (lb[j]->atom1 < lb[j]->atom2
                     ||
                     !unidirectional
                )
@@ -2222,6 +2222,10 @@ float Molecule::get_internal_clashes()
         {
             if (atoms[i]->is_bonded_to(atoms[j]) || atoms[j]->is_bonded_to(atoms[i]))
             {
+                #if _dbg_unreciprocated_bonds
+                throw 0x20240531;
+                #endif
+
                 Bond* ab = atoms[i]->get_bond_between(atoms[j]);
                 if (atoms[i] < atoms[j] && atoms[i]->is_pi() && atoms[j]->is_pi() && !atoms[i]->in_same_ring_as(atoms[j]))
                 {
@@ -2268,8 +2272,8 @@ float Molecule::get_internal_clashes()
                     atoms[i]->fetch_bonds(b);
                     int k;
                     for (k=0; k<g; k++)
-                        cout << atoms[i]->name << " is bonded to " << hex << b[k]->btom << dec << " "
-                             << (b[k]->btom ? b[k]->btom->name : "") << "." << endl;
+                        cout << atoms[i]->name << " is bonded to " << hex << b[k]->atom2 << dec << " "
+                             << (b[k]->atom2 ? b[k]->atom2->name : "") << "." << endl;
                 }
             }
         }
@@ -3039,7 +3043,7 @@ void Molecule::do_histidine_flip(HistidineFlip* hf)
     Point newloc = rotate3D(ptH, Navg, ptC.subtract(Navg), M_PI);
     hf->H->move(newloc);
 
-    Atom* was_bonded = hf->H->get_bond_by_idx(0)->btom;
+    Atom* was_bonded = hf->H->get_bond_by_idx(0)->atom2;
     hf->H->unbond(was_bonded);
     float rN1 = newloc.get_3d_distance(ptN1), rN2 = newloc.get_3d_distance(ptN2);
     Atom* new_bonded = (rN1 > rN2) ? hf->N2 : hf->N1;
@@ -3059,8 +3063,8 @@ float Molecule::get_springy_bond_satisfaction()
     int i;
     for (i=0; i<springy_bondct; i++)
     {
-        if (!springy_bonds[i].atom || !springy_bonds[i].btom || !springy_bonds[i].optimal_radius) continue;
-        float r = springy_bonds[i].atom->get_location().get_3d_distance(springy_bonds[i].btom->get_location());
+        if (!springy_bonds[i].atom1 || !springy_bonds[i].atom2 || !springy_bonds[i].optimal_radius) continue;
+        float r = springy_bonds[i].atom1->get_location().get_3d_distance(springy_bonds[i].atom2->get_location());
         r /= springy_bonds[i].optimal_radius;
         if (r < 1) retval += r;
         else retval += 1.0/(r*r);
@@ -3597,16 +3601,16 @@ void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molec
                     int q, rang=0;
                     for (q=0; bb[q]; q++)
                     {
-                        if (!bb[q]->count_moves_with_btom()) continue;
-                        if (!bb[q]->atom || !bb[q]->btom) continue;         // Sanity check, otherwise we're sure to get random foolish segfaults.
-                        if (bb[q]->atom->is_backbone && strcmp(bb[q]->atom->name, "CA")) continue;
-                        if (bb[q]->btom->is_backbone) continue;
+                        if (!bb[q]->count_moves_with_atom2()) continue;
+                        if (!bb[q]->atom1 || !bb[q]->atom2) continue;         // Sanity check, otherwise we're sure to get random foolish segfaults.
+                        if (bb[q]->atom1->is_backbone && strcmp(bb[q]->atom1->name, "CA")) continue;
+                        if (bb[q]->atom2->is_backbone) continue;
                         float theta;
-                        int heavy_atoms = bb[q]->count_heavy_moves_with_btom();
+                        int heavy_atoms = bb[q]->count_heavy_moves_with_atom2();
                         if (heavy_atoms && (!(a->movability & MOV_CAN_FLEX) || (a->movability & MOV_FORBIDDEN))) continue;
 
                         #if _dbg_mol_flexion
-                        bool is_flexion_dbg_mol_bond = is_flexion_dbg_mol & !strcmp(bb[q]->btom->name, "OG");
+                        bool is_flexion_dbg_mol_bond = is_flexion_dbg_mol & !strcmp(bb[q]->atom2->name, "OG");
                         #endif
 
                         if (do_full_rotation && a->is_residue() /*&& benerg <= 0*/ && bb[q]->can_rotate)
@@ -3663,11 +3667,11 @@ void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molec
                                 if (!bb[q]->flip_angle) bb[q]->flip_angle = M_PI;
                             }
 
-                            Ring* isra = bb[q]->atom->in_same_ring_as(bb[q]->btom);
+                            Ring* isra = bb[q]->atom1->in_same_ring_as(bb[q]->atom2);
                             if (isra)
                             {
                                 if (rang) continue;
-                                isra->flip_atom(bb[q]->atom);
+                                isra->flip_atom(bb[q]->atom1);
                                 rang++;
                                 flipped_rings = true;
                             }
@@ -4366,7 +4370,7 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
 	}
     Bond* a0b[16];
     ring_members[0]->fetch_bonds(a0b);
-    if (!a0b[0]->btom || !a0b[1]->btom)
+    if (!a0b[0]->atom2 || !a0b[1]->atom2)
     {
         cout << "Attempted to form coplanar ring with starting atom bonded to fewer than two other atoms." << endl;
         throw 0xbad12196;					// If you use your imagination, 12196 spells "ring".
@@ -4374,8 +4378,8 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
 
     Point A, B, C;
     A = ring_members[0]->get_location();
-    B = a0b[0]->btom->get_location();
-    C = a0b[1]->btom->get_location();
+    B = a0b[0]->atom2->get_location();
+    C = a0b[1]->atom2->get_location();
 
     normal = compute_normal(&A, &B, &C);
     while (!normal.r)
@@ -4411,30 +4415,30 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
             	// cout << "nullptr bond." << endl;
                 continue;
             }
-            if (!b2->btom)
+            if (!b2->atom2)
             {
-            	// cout << "nullptr btom." << endl;
+            	// cout << "nullptr atom2." << endl;
                 b2=0;
                 continue;
             }
             for (j=0; j<ringsz; j++)
             {
-            	if (ring_members[j] == b2->btom)
+            	if (ring_members[j] == b2->atom2)
                 {
-            		// cout << "btom is part of the ring." << endl;
+            		// cout << "atom2 is part of the ring." << endl;
                     b2 = 0;
                     break;
                 }
             }
             if (b2) break;
         }
-        if (b2 && b2->btom)
+        if (b2 && b2->atom2)
         {
-        	// cout << "found " << b2->btom->name << endl;
+        	// cout << "found " << b2->atom2->name << endl;
             Point ptnew = ring_members[l]->get_location().subtract(ringcen);
-            ptnew.scale(InteratomicForce::covalent_bond_radius(ring_members[l], b2->btom, b2->cardinality));
+            ptnew.scale(InteratomicForce::covalent_bond_radius(ring_members[l], b2->atom2, b2->cardinality));
             ptnew = ring_members[l]->get_location().add(ptnew);
-            b2->btom->move_assembly(&ptnew, ring_members[l]);
+            b2->atom2->move_assembly(&ptnew, ring_members[l]);
         }
     }
 }
@@ -4473,14 +4477,14 @@ float Molecule::close_loop(Atom** path, float lcard)
 
         for (j=0; j<geo; j++)
         {
-            if (b[j] && b[j]->btom
+            if (b[j] && b[j]->atom2
                     &&
                     (	b[j]->can_rotate
                         ||
                         b[j]->can_flip
                     )
                     &&
-                    strcmp(b[j]->btom->name, "N")
+                    strcmp(b[j]->atom2->name, "N")
                ) rotables[k++] = b[j];
         }
 
@@ -4515,18 +4519,18 @@ float Molecule::close_loop(Atom** path, float lcard)
     {
         for (i=0; rotables[i]; i++)
         {
-            float rr = rotables[i]->atom->get_location().get_3d_distance(rotables[i]->btom->get_location());
+            float rr = rotables[i]->atom1->get_location().get_3d_distance(rotables[i]->atom2->get_location());
 
             if (fabs(rr-bond_length) > 0.01)
             {
-                Point aloc = rotables[i]->atom->get_location();
-                Point bloc = rotables[i]->btom->get_location();
+                Point aloc = rotables[i]->atom1->get_location();
+                Point bloc = rotables[i]->atom2->get_location();
 
                 bloc = bloc.subtract(aloc);
                 bloc.scale(bond_length);
                 bloc = bloc.add(aloc);
 
-                rotables[i]->btom->move(bloc);
+                rotables[i]->atom2->move(bloc);
             }
 
             // issue_5
@@ -4881,58 +4885,58 @@ float Molecule::get_atom_error(int i, LocatedVector* best_lv, bool hemi)
     int j;
     float error = 0;
     Point bloc;
-    Atom* btom;
+    Atom* atom2;
     Bond* b[16];
     int g, bg;
     float b_bond_angle;
     LocatedVector lv;
 
-    // Get the atom's zero-index bonded atom. Call it btom (because why not overuse a foolish pun?).
+    // Get the atom's zero-index bonded atom. Call it atom2 (because why not overuse a foolish pun?).
     atoms[i]->fetch_bonds(b);
     if (!b[0]) return error;
-    btom = b[0]->btom;
+    atom2 = b[0]->atom2;
     float card = b[0]->cardinality;
-    if (!btom)
+    if (!atom2)
     {
         return error;
     }
 
-    bloc = btom->get_location();
+    bloc = atom2->get_location();
     g = atoms[i]->get_geometry();
-    bg = btom->get_geometry();
-    b_bond_angle = btom->get_geometric_bond_angle();
+    bg = atom2->get_geometry();
+    b_bond_angle = atom2->get_geometric_bond_angle();
 
-    // Make an imaginary sphere around btom, whose radius equals the optimal bond distance.
+    // Make an imaginary sphere around atom2, whose radius equals the optimal bond distance.
     lv.origin = bloc;
-    if (atoms[i]->get_Z() == 1 || btom->get_Z() == 1) card = 1;
-    float optimal_radius = InteratomicForce::covalent_bond_radius(atoms[i], btom, card);
+    if (atoms[i]->get_Z() == 1 || atom2->get_Z() == 1) card = 1;
+    float optimal_radius = InteratomicForce::covalent_bond_radius(atoms[i], atom2, card);
 
     lv = (SCoord)atoms[i]->get_location().subtract(bloc);
     lv.origin = bloc;
 
     error += _SANOM_BOND_RADIUS_WEIGHT * (fabs(optimal_radius-lv.r)/optimal_radius);
 
-    error += pow(_SANOM_BOND_ANGLE_WEIGHT*btom->get_bond_angle_anomaly(lv, atoms[i]), 2);
+    error += pow(_SANOM_BOND_ANGLE_WEIGHT*atom2->get_bond_angle_anomaly(lv, atoms[i]), 2);
 
     float thstep = fiftyseventh*5;
     float besttheta = 0, bestphi = 0, bestscore = 0;
     if (hemi)
     {
         bestscore = -1e9;
-        lv.r = InteratomicForce::covalent_bond_radius(atoms[i], btom, card);
+        lv.r = InteratomicForce::covalent_bond_radius(atoms[i], atom2, card);
         for (lv.theta = -square; lv.theta <= square; lv.theta += thstep)
         {
             float phstep = M_PI/(20.0*(sin(lv.theta) + 1));
             for (lv.phi = 0; lv.phi < (M_PI*2); lv.phi += phstep)
             {
                 // At many points along the sphere, evaluate the goodness-of-fit as a function of:
-                // Success in conforming to btom's geometry;
-                // Success in avoiding clashes with atoms not bonded to self or btom;
+                // Success in conforming to atom2's geometry;
+                // Success in avoiding clashes with atoms not bonded to self or atom2;
                 // Success in maintaining optimal binding distances to own bonded atoms.
                 // Later, we'll test edge cases where bond strain distorts the usual angles.
                 float score = 0;
 
-                score -= _SANOM_BOND_ANGLE_WEIGHT*btom->get_bond_angle_anomaly(lv, atoms[i]);
+                score -= _SANOM_BOND_ANGLE_WEIGHT*atom2->get_bond_angle_anomaly(lv, atoms[i]);
 
                 // Avoid clashes with strangers.
                 for (j=0; atoms[j]; j++)
@@ -4947,9 +4951,9 @@ float Molecule::get_atom_error(int i, LocatedVector* best_lv, bool hemi)
                 // Seek optimal bond radii.
                 for (j=1; b[j]; j++)
                 {
-                    if (!b[j]->btom) continue;
-                    float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->btom, b[j]->cardinality);
-                    float r = b[j]->btom->get_location().get_3d_distance(lv.to_point());
+                    if (!b[j]->atom2) continue;
+                    float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->atom2, b[j]->cardinality);
+                    float r = b[j]->atom2->get_location().get_3d_distance(lv.to_point());
 
                     score -= _SANOM_BOND_RAD_WEIGHT * fabs(optimal-r);
                 }
@@ -4983,9 +4987,9 @@ float Molecule::get_atom_error(int i, LocatedVector* best_lv, bool hemi)
 
     for (j=1; b[j]; j++)
     {
-        if (!b[j]->btom) continue;
-        float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->btom, b[j]->cardinality);
-        float r = b[j]->btom->get_location().get_3d_distance(lv.to_point());
+        if (!b[j]->atom2) continue;
+        float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->atom2, b[j]->cardinality);
+        float r = b[j]->atom2->get_location().get_3d_distance(lv.to_point());
 
         error += _SANOM_BOND_RAD_WEIGHT * fabs(optimal-r);
     }
@@ -5002,7 +5006,7 @@ float Molecule::correct_structure(int iters)
     Point zero(0,0,0);
     float error = 0;
     Point aloc, bloc;
-    Atom* btom;
+    Atom* atom2;
     Bond* b[16];
     int g, bg;
     float b_bond_angle;
@@ -5027,14 +5031,14 @@ float Molecule::correct_structure(int iters)
         error = 0;
         for (i=0; atoms[i]; i++)
         {
-            // Get the atom's zero-index bonded atom. Call it btom (because why not overuse a foolish pun?).
+            // Get the atom's zero-index bonded atom. Call it atom2 (because why not overuse a foolish pun?).
             atoms[i]->fetch_bonds(b);
             if (!b[0]) return error;
-            btom = b[0]->btom;
-            if (!btom) return error;
+            atom2 = b[0]->atom2;
+            if (!atom2) return error;
 
             // TODO
-            if (atoms[i]->num_rings() && atoms[i]->is_pi() && in_same_ring(atoms[i], btom)) continue;
+            if (atoms[i]->num_rings() && atoms[i]->is_pi() && in_same_ring(atoms[i], atom2)) continue;
 
             error += get_atom_error(i, &lv);
             if (!iter) continue;
@@ -5054,12 +5058,12 @@ float Molecule::correct_structure(int iters)
                             Point aloc = atoms[i]->get_location();
                             float rad = rcen.get_3d_distance(aloc);
 
-                            // Center ring at combined distance from btom.
+                            // Center ring at combined distance from atom2.
                             LocatedVector lvr = lv;
                             lvr.r += rad;
                             recenter_ring(j, lvr.to_point());
 
-                            // Rotate ring, and all assemblies, to align atom to btom.
+                            // Rotate ring, and all assemblies, to align atom to atom2.
                             Point atarget = lv.to_point();
                             aloc = atoms[i]->get_location();
                             rcen = get_ring_center(j);
@@ -5074,7 +5078,7 @@ float Molecule::correct_structure(int iters)
             else
             {
                 /*Point pt = lv.to_point();
-                atoms[i]->move_assembly(&pt, btom);*/
+                atoms[i]->move_assembly(&pt, atom2);*/
                 atoms[i]->move(lv.to_point());
             }
         }
@@ -5180,15 +5184,15 @@ float Molecule::get_atom_bond_length_anomaly(Atom* a, Atom* ignore)
     for (i=0; i<geometry; i++)
     {
         if (!thesebonds[i]) continue;
-        if (thesebonds[i]->btom)
+        if (thesebonds[i]->atom2)
         {
-            if (thesebonds[i]->btom == ignore) continue;
-            float optimal = InteratomicForce::covalent_bond_radius(a, thesebonds[i]->btom, thesebonds[i]->cardinality);
-            float r = a->distance_to(thesebonds[i]->btom);
+            if (thesebonds[i]->atom2 == ignore) continue;
+            float optimal = InteratomicForce::covalent_bond_radius(a, thesebonds[i]->atom2, thesebonds[i]->cardinality);
+            float r = a->distance_to(thesebonds[i]->atom2);
             anomaly += pow(1.0+fabs(r-optimal)/optimal, 4)-1;
 
             #if _dbg_molstruct_evolution_bond_lengths
-            if (fabs(r-optimal) > 0.01) cout << "Atoms " << a->name << " and " << thesebonds[i]->btom->name
+            if (fabs(r-optimal) > 0.01) cout << "Atoms " << a->name << " and " << thesebonds[i]->atom2->name
                 << ", cardinality = " << thesebonds[i]->cardinality
                 << " should be " << optimal << "Å apart, but they're " << r << endl;
             #endif
@@ -5250,7 +5254,7 @@ float Molecule::evolve_structure(int gens, float mr, int ps)
                         Bond* b0 = atoms[j]->get_bond_by_idx(0);
                         if (b0)
                         {
-                            Atom* aparent = b0->btom;
+                            Atom* aparent = b0->atom2;
                             if (aparent)
                             {
                                 optimal = InteratomicForce::covalent_bond_radius(atoms[j], aparent, b0->cardinality);
@@ -5272,7 +5276,7 @@ float Molecule::evolve_structure(int gens, float mr, int ps)
                 Bond* b0 = atoms[j]->get_bond_by_idx(0);
                 if (!b0) continue;
 
-                Atom* aparent = b0->btom;
+                Atom* aparent = b0->atom2;
                 if (!aparent) continue;
 
                 anomaly += get_atom_bond_length_anomaly(aparent, atoms[j]);

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -462,7 +462,7 @@ void Molecule::hydrogenate(bool steric_only)
         {
             for (j=0; aib[j]; j++)
             {
-                if (aib[j]->atom2) bcardsum += aib[j]->cardinality;
+                if (aib[j]->get_atom2()) bcardsum += aib[j]->cardinality;
                 if (aib[j]->cardinality > 1) db++;
             }
         }
@@ -507,23 +507,23 @@ void Molecule::hydrogenate(bool steric_only)
             if (atoms[i]->get_geometry() == 3)
             {
                 Bond* aib = atoms[i]->get_bond_by_idx(1);
-                if (1) // aib && aib->total_rotations) // aib->atom2 == H)
+                if (1) // aib && aib->total_rotations) // aib->get_atom2() == H)
                 {
                     /*Bond* b0 = atoms[i]->get_bond_by_idx(0);
                     Bond* b1 = atoms[i]->get_bond_by_idx(1);
-                    if (!b1 || !b1->atom2) b1 = atoms[i]->get_bond_by_idx(2);*/
+                    if (!b1 || !b1->get_atom2()) b1 = atoms[i]->get_bond_by_idx(2);*/
 
                     int k=0;
                     Bond* b0 = atoms[i]->get_bond_by_idx(k++);
-                    if (!b0->atom2 || b0->atom2 == H) b0 = atoms[i]->get_bond_by_idx(k++);
+                    if (!b0->get_atom2() || b0->get_atom2() == H) b0 = atoms[i]->get_bond_by_idx(k++);
                     Bond* b1 = atoms[i]->get_bond_by_idx(k++);
-                    if (!b1->atom2 || b1->atom2 == H) b1 = atoms[i]->get_bond_by_idx(k++);
+                    if (!b1->get_atom2() || b1->get_atom2() == H) b1 = atoms[i]->get_bond_by_idx(k++);
 
-                    if (b0->atom2 && b1->atom2 && (abs((__int64_t)(b1) - (__int64_t)b1->atom2) < memsanity))
+                    if (b0->get_atom2() && b1->get_atom2() && (abs((__int64_t)(b1) - (__int64_t)b1->get_atom2()) < memsanity))
                     {
                         Point source = atoms[i]->get_location();
-                        /*Point axis = b0->atom2->get_location();
-                        Point avoid = b1->atom2->get_location();
+                        /*Point axis = b0->get_atom2()->get_location();
+                        Point avoid = b1->get_atom2()->get_location();
                         Point movable = H->get_location();
                         SCoord v(axis.subtract(source));
 
@@ -533,15 +533,15 @@ void Molecule::hydrogenate(bool steric_only)
 
                         if (r_is < r_wouldbe) H->move(visibly_moved);*/
 
-                        Point movable = b1->atom2->get_location();
+                        Point movable = b1->get_atom2()->get_location();
                         /*cout << "Getting normal of " << atoms[i]->name << " - "
-                        	 << b0->atom2->name << " - " << b1->atom2->name << endl;*/
-                        SCoord axis = compute_normal(source, b0->atom2->get_location(), b1->atom2->get_location());
+                        	 << b0->get_atom2()->name << " - " << b1->get_atom2()->name << endl;*/
+                        SCoord axis = compute_normal(source, b0->get_atom2()->get_location(), b1->get_atom2()->get_location());
                         Point plus  = rotate3D(movable, source, axis,  triangular);
                         Point minus = rotate3D(movable, source, axis, -triangular);
 
-                        float rp = plus.get_3d_distance(b0->atom2->get_location());
-                        float rm = minus.get_3d_distance(b0->atom2->get_location());
+                        float rp = plus.get_3d_distance(b0->get_atom2()->get_location());
+                        float rm = minus.get_3d_distance(b0->get_atom2()->get_location());
 
                         Point pt = ((rp > rm) ? plus : minus).subtract(source);
                         pt.scale(InteratomicForce::covalent_bond_radius(atoms[i], H, 1));
@@ -680,30 +680,30 @@ float Molecule::total_eclipses()
             if (!abt[j]) continue;
             if (abt[j]->cardinality > 1) continue;
             if (!abt[j]->can_rotate) continue;
-            if (!abt[j]->atom2) continue;
-            if (abt[j]->atom2->get_Z() < 2) continue;
-            if (atoms[i]->is_pi() && abt[j]->atom2->is_pi()) continue;
-            if (atoms[i]->is_backbone && abt[j]->atom2->is_backbone) continue;
-            SCoord axis = abt[j]->atom2->get_location().subtract(atoms[i]->get_location());
+            if (!abt[j]->get_atom2()) continue;
+            if (abt[j]->get_atom2()->get_Z() < 2) continue;
+            if (atoms[i]->is_pi() && abt[j]->get_atom2()->is_pi()) continue;
+            if (atoms[i]->is_backbone && abt[j]->get_atom2()->is_backbone) continue;
+            SCoord axis = abt[j]->get_atom2()->get_location().subtract(atoms[i]->get_location());
             Bond* bbt[16];
-            abt[j]->atom2->fetch_bonds(bbt);
-            m = abt[j]->atom2->get_geometry();
+            abt[j]->get_atom2()->fetch_bonds(bbt);
+            m = abt[j]->get_atom2()->get_geometry();
             for (k=0; k<m; k++)
             {
                 if (!bbt[k]) continue;
-                if (!bbt[k]->atom2) continue;
-                if (bbt[k]->atom2 == atoms[i]) continue;
+                if (!bbt[k]->get_atom2()) continue;
+                if (bbt[k]->get_atom2() == atoms[i]) continue;
                 for (l=0; l<n; l++)
                 {
                     if (l == j) continue;
                     if (!abt[l]) continue;
-                    if (!abt[l]->atom2) continue;
-                    float theta = find_angle_along_vector(bbt[k]->atom2->get_location(), abt[l]->atom2->get_location(), atoms[i]->get_location(), axis);
+                    if (!abt[l]->get_atom2()) continue;
+                    float theta = find_angle_along_vector(bbt[k]->get_atom2()->get_location(), abt[l]->get_atom2()->get_location(), atoms[i]->get_location(), axis);
                     if (theta >= -hexagonal && theta <= hexagonal)
                     {
                         #if _dbg_eclipses
-                        cout << bbt[k]->atom2->name << " is " << (theta*fiftyseven) << "deg from " << abt[l]->atom2->name
-                            << " along the " << atoms[i]->name << " - " << abt[j]->atom2->name << " axis."
+                        cout << bbt[k]->get_atom2()->name << " is " << (theta*fiftyseven) << "deg from " << abt[l]->get_atom2()->name
+                            << " along the " << atoms[i]->name << " - " << abt[j]->get_atom2()->name << " axis."
                             << endl;
                         #endif
                         theta = hexagonal - fabs(theta);
@@ -1080,7 +1080,7 @@ int Molecule::get_bond_count(bool unidirectional) const
 
         for (j=0; b[j]; j++)
         {
-            if (b[j]->atom2 > atoms[i] || !unidirectional) bc++;
+            if (b[j]->get_atom2() > atoms[i] || !unidirectional) bc++;
         }
     }
 
@@ -1203,8 +1203,8 @@ bool Molecule::save_sdf(FILE* os, Molecule** lig)
 
         for (j=0; j<ac; j++)
         {
-            if (latoms[j] == lbonds[i]->atom1) laidx = j+1;
-            if (latoms[j] == lbonds[i]->atom2) lbidx = j+1;
+            if (latoms[j] == lbonds[i]->get_atom1()) laidx = j+1;
+            if (latoms[j] == lbonds[i]->get_atom2()) lbidx = j+1;
         }
 
         // fprintf(os, " %d %d  %d  0  0  0  0\n", laidx, lbidx, (int)lbonds[i]->cardinality);
@@ -1477,13 +1477,13 @@ void Molecule::find_paths()
     n=0;
     for (i=0; b[i]; i++)
     {
-        if (!b[i]->atom2) continue;
-        if (b[i]->atom2->get_Z() < 2) continue;
-        if (b[i]->atom2->residue && b[i]->atom2->residue != a->residue) continue;
+        if (!b[i]->get_atom2()) continue;
+        if (b[i]->get_atom2()->get_Z() < 2) continue;
+        if (b[i]->get_atom2()->residue && b[i]->get_atom2()->residue != a->residue) continue;
         paths[n] = new Atom*[atcount];
         for (q=0; q<atcount; q++) paths[n][q] = nullptr;
         paths[n][0] = a;
-        paths[n][1] = b[i]->atom2;
+        paths[n][1] = b[i]->get_atom2();
         paths[n][2] = nullptr;
         n++;
     }
@@ -1508,17 +1508,17 @@ void Molecule::find_paths()
             for (j=0; b[j]; j++)
             {
                 if (abs((__int64_t)(a) - (__int64_t)b[j]) > memsanity) break;
-                if (abs((__int64_t)(b[j]) - (__int64_t)b[j]->atom2) > memsanity) break;
-                if (!b[j]->atom2) continue;
-                if (b[j]->atom2->get_Z() < 2) continue;
-                if (b[j]->atom2->get_bonded_heavy_atoms_count() < 2) continue;
-                if (b[j]->atom2->residue && b[j]->atom2->residue != a->residue) continue;
+                if (abs((__int64_t)(b[j]) - (__int64_t)b[j]->get_atom2()) > memsanity) break;
+                if (!b[j]->get_atom2()) continue;
+                if (b[j]->get_atom2()->get_Z() < 2) continue;
+                if (b[j]->get_atom2()->get_bonded_heavy_atoms_count() < 2) continue;
+                if (b[j]->get_atom2()->residue && b[j]->get_atom2()->residue != a->residue) continue;
 
                 #if _dbg_path_search
-                cout << "Trying " << b[j]->atom2->name << "... ";
+                cout << "Trying " << b[j]->get_atom2()->name << "... ";
                 #endif
 
-                l = path_contains_atom(i, b[j]->atom2);
+                l = path_contains_atom(i, b[j]->get_atom2());
                 if (l > 0)
                 {
                     if ((m-l) > 1)
@@ -1528,7 +1528,7 @@ void Molecule::find_paths()
                         {
                             ring_atoms[h-l] = paths[i][h];
                         }
-                        ring_atoms[h-l] = b[j]->atom2;
+                        ring_atoms[h-l] = b[j]->get_atom2();
                         h++;
                         ring_atoms[h-l] = nullptr;
 
@@ -1545,7 +1545,7 @@ void Molecule::find_paths()
                     paths[n] = new Atom*[atcount];
                     for (q=0; q<atcount; q++) paths[n][q] = nullptr;
                     copy_path(i, n);
-                    paths[n][m] = b[j]->atom2;
+                    paths[n][m] = b[j]->get_atom2();
                     paths[n][m+1] = nullptr;
 
                     #if _dbg_path_search
@@ -1638,9 +1638,9 @@ void Molecule::identify_acidbase()
                     for (j=0; j<nb2; j++)
                     {
                         if (!b[j]) break;
-                        if (!b[j]->atom2) break;
-                        if (!b[j]->atom2->get_Z()) break;
-                        planarity_check[l++] = b[j]->atom2->get_location();
+                        if (!b[j]->get_atom2()) break;
+                        if (!b[j]->get_atom2()->get_Z()) break;
+                        planarity_check[l++] = b[j]->get_atom2()->get_location();
                     }
 
                     bool lplanar = false;
@@ -1665,20 +1665,20 @@ void Molecule::identify_acidbase()
                         for (j=0; j<l; j++)
                         {
                             if (!b[j]) break;
-                            if (!b[j]->atom2) break;
-                            if (!b[j]->atom2->get_Z()) break;
-                            int bfam = b[j]->atom2->get_family();
+                            if (!b[j]->get_atom2()) break;
+                            if (!b[j]->get_atom2()->get_Z()) break;
+                            int bfam = b[j]->get_atom2()->get_family();
                             if (bfam == PNICTOGEN || bfam == CHALCOGEN)
                             {
-                                b[j]->atom2->aromatize();
+                                b[j]->get_atom2()->aromatize();
                                 b[j]->cardinality = 1.5;
 
-                                if (bfam == CHALCOGEN && b[j]->atom2->get_bonded_heavy_atoms_count() < 2)
+                                if (bfam == CHALCOGEN && b[j]->get_atom2()->get_bonded_heavy_atoms_count() < 2)
                                 {
                                     chalcogens++;
-                                    if (chalcogens > 1 && !b[j]->atom2->get_charge())
+                                    if (chalcogens > 1 && !b[j]->get_atom2()->get_charge())
                                     {
-                                        b[j]->atom2->increment_charge(-1);
+                                        b[j]->get_atom2()->increment_charge(-1);
                                         chalcogens = -65536;
                                     }
                                 }
@@ -1696,10 +1696,10 @@ void Molecule::identify_acidbase()
                 }
                 for (j=0; b[j]; j++)
                 {
-                    if (!b[j]->atom2) continue;
+                    if (!b[j]->get_atom2()) continue;
                     if (b[j]->cardinality == 2)
                     {
-                        int fam = b[j]->atom2->get_family();
+                        int fam = b[j]->get_atom2()->get_family();
                         if (fam != CHALCOGEN)
                         {
                             goto _not_acidic;
@@ -1709,8 +1709,8 @@ void Molecule::identify_acidbase()
             }
             for (j=0; b[j]; j++)
             {
-                if (!b[j]->atom2) continue;
-                int fam = b[j]->atom2->get_family();
+                if (!b[j]->get_atom2()) continue;
+                int fam = b[j]->get_atom2()->get_family();
                 if (carbon && fam == PNICTOGEN)
                 {
                     goto _not_acidic;
@@ -1718,7 +1718,7 @@ void Molecule::identify_acidbase()
                 //cout << "Fam: " << fam << endl;
                 if (fam == CHALCOGEN && b[j]->cardinality < 2)
                 {
-                    if (b[j]->atom2->get_charge() < 0)
+                    if (b[j]->get_atom2()->get_charge() < 0)
                     {
                         sbOH++;
                         break;
@@ -1726,15 +1726,15 @@ void Molecule::identify_acidbase()
                     else
                     {
                         Bond* b1[16];
-                        b[j]->atom2->fetch_bonds(b1);
+                        b[j]->get_atom2()->fetch_bonds(b1);
                         if (!b1[0])
                         {
                             goto _not_acidic;
                         }
                         for (k=0; b1[k]; k++)
                         {
-                            if (!b1[k]->atom2) continue;
-                            if (b1[k]->atom2->get_Z() == 1)
+                            if (!b1[k]->get_atom2()) continue;
+                            if (b1[k]->get_atom2()->get_Z() == 1)
                             {
                                 sbOH++;
                                 //cout << "OH" << endl;
@@ -1750,12 +1750,12 @@ void Molecule::identify_acidbase()
             atoms[i]->fetch_bonds(b);
             for (j=0; b[j]; j++)
             {
-                if (!b[j]->atom2) continue;
-                int fam = b[j]->atom2->get_family();
+                if (!b[j]->get_atom2()) continue;
+                int fam = b[j]->get_atom2()->get_family();
                 if (fam == CHALCOGEN)
                 {
-                    b[j]->atom2->set_acidbase(-1);
-                    //cout << "Atom " << b[j]->atom2->name << " is acidic." << endl;
+                    b[j]->get_atom2()->set_acidbase(-1);
+                    //cout << "Atom " << b[j]->get_atom2()->name << " is acidic." << endl;
                 }
             }
         }
@@ -1814,8 +1814,8 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
         Star s;
         s.pmol = this;
         if (!rotatable_bonds) rotatable_bonds = s.paa->get_rotatable_bonds();
-        else if (rotatable_bonds[0] && rotatable_bonds[1] && rotatable_bonds[0]->atom1 == rotatable_bonds[1]->atom1) rotatable_bonds = s.paa->get_rotatable_bonds();
-        else if (rotatable_bonds[0] && abs(rotatable_bonds[0]->atom1 - rotatable_bonds[0]->atom2) >= 524288) rotatable_bonds = s.paa->get_rotatable_bonds();
+        else if (rotatable_bonds[0] && rotatable_bonds[1] && rotatable_bonds[0]->get_atom1() == rotatable_bonds[1]->get_atom1()) rotatable_bonds = s.paa->get_rotatable_bonds();
+        else if (rotatable_bonds[0] && abs(rotatable_bonds[0]->get_atom1() - rotatable_bonds[0]->get_atom2()) >= 524288) rotatable_bonds = s.paa->get_rotatable_bonds();
         return rotatable_bonds;
     }
     // cout << name << " Molecule::get_rotatable_bonds()" << endl << flush;
@@ -1832,18 +1832,18 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
             int g = atoms[i]->get_geometry();
             for (j=0; j<g && lb[j]; j++)
             {
-                if (!lb[j]->atom1 || !lb[j]->atom2) continue;
+                if (!lb[j]->get_atom1() || !lb[j]->get_atom2()) continue;
 
-                if (lb[j]->cardinality > 1 && (!lb[j]->atom1->is_pi() || !lb[j]->atom2->is_pi()) && lb[j]->cardinality < 3)
+                if (lb[j]->cardinality > 1 && (!lb[j]->get_atom1()->is_pi() || !lb[j]->get_atom2()->is_pi()) && lb[j]->cardinality < 3)
                     lb[j]->cardinality = 1;
 
-                bool pia = lb[j]->atom1->is_pi(),
-                     pib = lb[j]->atom2->is_pi();
+                bool pia = lb[j]->get_atom1()->is_pi(),
+                     pib = lb[j]->get_atom2()->is_pi();
 
-                int fa = lb[j]->atom1->get_family(),
-                    fb = lb[j]->atom2->get_family();
+                int fa = lb[j]->get_atom1()->get_family(),
+                    fb = lb[j]->get_atom2()->get_family();
 
-                if (lb[j]->atom1->in_same_ring_as(lb[j]->atom2))
+                if (lb[j]->get_atom1()->in_same_ring_as(lb[j]->get_atom2()))
                 {
                     #if _ALLOW_FLEX_RINGS
                     lb[j]->can_flip = !lb[j]->caged && (lb[j]->cardinality == 1);
@@ -1863,23 +1863,23 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
                     lb[j]->can_rotate = false;
                     if ((fa == CHALCOGEN || fb == CHALCOGEN)
                         && fa != fb
-                        && lb[j]->atom2->get_bonded_atoms_count() > 1
+                        && lb[j]->get_atom2()->get_bonded_atoms_count() > 1
                         ) lb[j]->can_flip = !lb[j]->caged;
                 }
 
                 // If atoms a and b are pi, and a-b cannot rotate, then a-b can flip.
                 if (!lb[j]->can_rotate
-                    && lb[j]->atom2->is_bonded_to(CHALCOGEN)
+                    && lb[j]->get_atom2()->is_bonded_to(CHALCOGEN)
                     && fa != CHALCOGEN
-                    && !(lb[j]->atom1->in_same_ring_as(lb[j]->atom2))
+                    && !(lb[j]->get_atom1()->in_same_ring_as(lb[j]->get_atom2()))
                     )
                 {
                     lb[j]->can_flip = !lb[j]->caged;
                 }
 
-                if (lb[j]->atom2
+                if (lb[j]->get_atom2()
                         &&
-                        lb[j]->atom1 < lb[j]->atom2
+                        lb[j]->get_atom1() < lb[j]->get_atom2()
                         &&
                         (lb[j]->can_rotate || (icf && lb[j]->can_flip))
                    )
@@ -1899,35 +1899,35 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
             {
                 // Generally, a single bond between pi atoms cannot rotate.
                 // Same if pi atom bonded to a pnictogen or chalcogen without a single bond to other atoms.
-                if (lb[j]->atom1 && lb[j]->atom2
+                if (lb[j]->get_atom1() && lb[j]->get_atom2()
                     &&  (
                             (
-                                lb[j]->atom1->is_pi() &&
-                                (   lb[j]->atom2->is_pi()
+                                lb[j]->get_atom1()->is_pi() &&
+                                (   lb[j]->get_atom2()->is_pi()
                                     ||
                                     (   
-                                        !lb[j]->atom2->is_bonded_to_pi(TETREL, false)
+                                        !lb[j]->get_atom2()->is_bonded_to_pi(TETREL, false)
                                         &&
                                         (
-                                            lb[j]->atom2->get_family() == PNICTOGEN
+                                            lb[j]->get_atom2()->get_family() == PNICTOGEN
                                             ||
-                                            lb[j]->atom2->get_family() == CHALCOGEN
+                                            lb[j]->get_atom2()->get_family() == CHALCOGEN
                                         )
                                     )
                                 )
                             )
                             ||
                             (
-                                lb[j]->atom2->is_pi() &&
-                                (   lb[j]->atom1->is_pi()
+                                lb[j]->get_atom2()->is_pi() &&
+                                (   lb[j]->get_atom1()->is_pi()
                                     ||
                                     (   
-                                        !lb[j]->atom1->is_bonded_to_pi(TETREL, false)
+                                        !lb[j]->get_atom1()->is_bonded_to_pi(TETREL, false)
                                         &&
                                         (
-                                            lb[j]->atom1->get_family() == PNICTOGEN
+                                            lb[j]->get_atom1()->get_family() == PNICTOGEN
                                             ||
-                                            lb[j]->atom1->get_family() == CHALCOGEN
+                                            lb[j]->get_atom1()->get_family() == CHALCOGEN
                                         )
                                     )
                                 )
@@ -1938,15 +1938,15 @@ Bond** Molecule::get_rotatable_bonds(bool icf)
 
                 if ((lb[j]->can_rotate || (icf && lb[j]->can_flip))
                         &&
-                        lb[j]->atom1 && lb[j]->atom2
+                        lb[j]->get_atom1() && lb[j]->get_atom2()
                         &&
-                        (!lb[j]->atom1->is_backbone || !strcmp(lb[j]->atom1->name, "CA"))
+                        (!lb[j]->get_atom1()->is_backbone || !strcmp(lb[j]->get_atom1()->name, "CA"))
                         &&
-                        !lb[j]->atom2->is_backbone
+                        !lb[j]->get_atom2()->is_backbone
                         &&
-                        greek_from_aname(lb[j]->atom1->name) == (greek_from_aname(lb[j]->atom2->name)-1)
+                        greek_from_aname(lb[j]->get_atom1()->name) == (greek_from_aname(lb[j]->get_atom2()->name)-1)
                         &&
-                        lb[j]->atom2->get_Z() > 1
+                        lb[j]->get_atom2()->get_Z() > 1
                    )
                 {
                     btemp[bonds++] = lb[j];
@@ -2055,10 +2055,10 @@ Bond** AminoAcid::get_rotatable_bonds()
                             for (o=0; o<ag; o++)
                                 if (lbb[o]
                                     && (abs((__int64_t)(this) - (__int64_t)lbb[o]) < memsanity)
-                                    && lbb[o]->atom2
-                                    && (abs((__int64_t)(this) - (__int64_t)lbb[o]->atom2) < memsanity)
+                                    && lbb[o]->get_atom2()
+                                    && (abs((__int64_t)(this) - (__int64_t)lbb[o]->get_atom2()) < memsanity)
                                     )
-                                    cout << " " << lbb[o]->atom2->name;
+                                    cout << " " << lbb[o]->get_atom2()->name;
                             cout << "." << endl;
                         }
 
@@ -2070,7 +2070,7 @@ Bond** AminoAcid::get_rotatable_bonds()
                             {
                                 cout << lba->name << " is bonded to:";
                                 int o, ag = lba->get_geometry();
-                                for (o=0; o<ag; o++) if (lbb[o]->atom2) cout << " " << lbb[o]->atom2->name;
+                                for (o=0; o<ag; o++) if (lbb[o]->get_atom2()) cout << " " << lbb[o]->get_atom2()->name;
                                 cout << "." << endl;
                             }
                         }
@@ -2080,7 +2080,7 @@ Bond** AminoAcid::get_rotatable_bonds()
                     {
                         // cout << (name ? name : "(no name)") << ":" << *(lb) << endl;
                         // Generally, a single bond between pi atoms cannot rotate.
-                        if (lb->atom1->is_pi() && lb->atom2 && lb->atom2->is_pi())
+                        if (lb->get_atom1()->is_pi() && lb->get_atom2() && lb->get_atom2()->is_pi())
                         {
                             lb->can_rotate = false;
                             lb->can_flip = !lb->caged;
@@ -2093,18 +2093,18 @@ Bond** AminoAcid::get_rotatable_bonds()
                                 &&
                                 la->get_Z() > 1
                                 &&
-                                (	greek_from_aname(la->name) == (greek_from_aname(lb->atom2->name)+1)
+                                (	greek_from_aname(la->name) == (greek_from_aname(lb->get_atom2()->name)+1)
                                     ||
-                                    greek_from_aname(la->name) == (greek_from_aname(lb->atom2->name)-1)
+                                    greek_from_aname(la->name) == (greek_from_aname(lb->get_atom2()->name)-1)
                                 )
                            )
                         {
                             // cout << "Included." << endl;
 
-                            if (greek_from_aname(la->name) < greek_from_aname(lb->atom2->name))
-                                btemp[bonds] = la->get_bond_between(lb->atom2);
+                            if (greek_from_aname(la->name) < greek_from_aname(lb->get_atom2()->name))
+                                btemp[bonds] = la->get_bond_between(lb->get_atom2());
                             else
-                                btemp[bonds] = lb->atom2->get_bond_between(la);
+                                btemp[bonds] = lb->get_atom2()->get_bond_between(la);
 
                             btemp[++bonds] = 0;
 
@@ -2129,15 +2129,15 @@ Bond** AminoAcid::get_rotatable_bonds()
             if (!lb[j]) break;
             if (lb[j]->can_rotate
                     &&
-                    lb[j]->atom1 && lb[j]->atom2
+                    lb[j]->get_atom1() && lb[j]->get_atom2()
                     &&
-                    (!lb[j]->atom1->is_backbone || !strcmp(lb[j]->atom1->name, "CA"))
+                    (!lb[j]->get_atom1()->is_backbone || !strcmp(lb[j]->get_atom1()->name, "CA"))
                     &&
-                    !lb[j]->atom2->is_backbone
+                    !lb[j]->get_atom2()->is_backbone
                     &&
-                    greek_from_aname(lb[j]->atom1->name) == (greek_from_aname(lb[j]->atom2->name)-1)
+                    greek_from_aname(lb[j]->get_atom1()->name) == (greek_from_aname(lb[j]->get_atom2()->name)-1)
                     &&
-                    lb[j]->atom2->get_Z() > 1
+                    lb[j]->get_atom2()->get_Z() > 1
                )
             {
                 // cout << *lb[j] << " ";
@@ -2187,7 +2187,7 @@ Bond** Molecule::get_all_bonds(bool unidirectional)
         for (j=0; j<g; j++)
         {
             if (!lb[j]) break;
-            if (lb[j]->atom1 < lb[j]->atom2
+            if (lb[j]->get_atom1() < lb[j]->get_atom2()
                     ||
                     !unidirectional
                )
@@ -2222,10 +2222,6 @@ float Molecule::get_internal_clashes()
         {
             if (atoms[i]->is_bonded_to(atoms[j]) || atoms[j]->is_bonded_to(atoms[i]))
             {
-                #if _dbg_unreciprocated_bonds
-                throw 0x20240531;
-                #endif
-
                 Bond* ab = atoms[i]->get_bond_between(atoms[j]);
                 if (atoms[i] < atoms[j] && atoms[i]->is_pi() && atoms[j]->is_pi() && !atoms[i]->in_same_ring_as(atoms[j]))
                 {
@@ -2272,8 +2268,8 @@ float Molecule::get_internal_clashes()
                     atoms[i]->fetch_bonds(b);
                     int k;
                     for (k=0; k<g; k++)
-                        cout << atoms[i]->name << " is bonded to " << hex << b[k]->atom2 << dec << " "
-                             << (b[k]->atom2 ? b[k]->atom2->name : "") << "." << endl;
+                        cout << atoms[i]->name << " is bonded to " << hex << b[k]->get_atom2() << dec << " "
+                             << (b[k]->get_atom2() ? b[k]->get_atom2()->name : "") << "." << endl;
                 }
             }
         }
@@ -3043,7 +3039,7 @@ void Molecule::do_histidine_flip(HistidineFlip* hf)
     Point newloc = rotate3D(ptH, Navg, ptC.subtract(Navg), M_PI);
     hf->H->move(newloc);
 
-    Atom* was_bonded = hf->H->get_bond_by_idx(0)->atom2;
+    Atom* was_bonded = hf->H->get_bond_by_idx(0)->get_atom2();
     hf->H->unbond(was_bonded);
     float rN1 = newloc.get_3d_distance(ptN1), rN2 = newloc.get_3d_distance(ptN2);
     Atom* new_bonded = (rN1 > rN2) ? hf->N2 : hf->N1;
@@ -3063,8 +3059,8 @@ float Molecule::get_springy_bond_satisfaction()
     int i;
     for (i=0; i<springy_bondct; i++)
     {
-        if (!springy_bonds[i].atom1 || !springy_bonds[i].atom2 || !springy_bonds[i].optimal_radius) continue;
-        float r = springy_bonds[i].atom1->get_location().get_3d_distance(springy_bonds[i].atom2->get_location());
+        if (!springy_bonds[i].get_atom1() || !springy_bonds[i].get_atom2() || !springy_bonds[i].optimal_radius) continue;
+        float r = springy_bonds[i].get_atom1()->get_location().get_3d_distance(springy_bonds[i].get_atom2()->get_location());
         r /= springy_bonds[i].optimal_radius;
         if (r < 1) retval += r;
         else retval += 1.0/(r*r);
@@ -3602,15 +3598,15 @@ void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molec
                     for (q=0; bb[q]; q++)
                     {
                         if (!bb[q]->count_moves_with_atom2()) continue;
-                        if (!bb[q]->atom1 || !bb[q]->atom2) continue;         // Sanity check, otherwise we're sure to get random foolish segfaults.
-                        if (bb[q]->atom1->is_backbone && strcmp(bb[q]->atom1->name, "CA")) continue;
-                        if (bb[q]->atom2->is_backbone) continue;
+                        if (!bb[q]->get_atom1() || !bb[q]->get_atom2()) continue;         // Sanity check, otherwise we're sure to get random foolish segfaults.
+                        if (bb[q]->get_atom1()->is_backbone && strcmp(bb[q]->get_atom1()->name, "CA")) continue;
+                        if (bb[q]->get_atom2()->is_backbone) continue;
                         float theta;
                         int heavy_atoms = bb[q]->count_heavy_moves_with_atom2();
                         if (heavy_atoms && (!(a->movability & MOV_CAN_FLEX) || (a->movability & MOV_FORBIDDEN))) continue;
 
                         #if _dbg_mol_flexion
-                        bool is_flexion_dbg_mol_bond = is_flexion_dbg_mol & !strcmp(bb[q]->atom2->name, "OG");
+                        bool is_flexion_dbg_mol_bond = is_flexion_dbg_mol & !strcmp(bb[q]->get_atom2()->name, "OG");
                         #endif
 
                         if (do_full_rotation && a->is_residue() /*&& benerg <= 0*/ && bb[q]->can_rotate)
@@ -3667,11 +3663,11 @@ void Molecule::conform_molecules(Molecule** mm, int iters, void (*cb)(int, Molec
                                 if (!bb[q]->flip_angle) bb[q]->flip_angle = M_PI;
                             }
 
-                            Ring* isra = bb[q]->atom1->in_same_ring_as(bb[q]->atom2);
+                            Ring* isra = bb[q]->get_atom1()->in_same_ring_as(bb[q]->get_atom2());
                             if (isra)
                             {
                                 if (rang) continue;
-                                isra->flip_atom(bb[q]->atom1);
+                                isra->flip_atom(bb[q]->get_atom1());
                                 rang++;
                                 flipped_rings = true;
                             }
@@ -4370,7 +4366,7 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
 	}
     Bond* a0b[16];
     ring_members[0]->fetch_bonds(a0b);
-    if (!a0b[0]->atom2 || !a0b[1]->atom2)
+    if (!a0b[0]->get_atom2() || !a0b[1]->get_atom2())
     {
         cout << "Attempted to form coplanar ring with starting atom bonded to fewer than two other atoms." << endl;
         throw 0xbad12196;					// If you use your imagination, 12196 spells "ring".
@@ -4378,8 +4374,8 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
 
     Point A, B, C;
     A = ring_members[0]->get_location();
-    B = a0b[0]->atom2->get_location();
-    C = a0b[1]->atom2->get_location();
+    B = a0b[0]->get_atom2()->get_location();
+    C = a0b[1]->get_atom2()->get_location();
 
     normal = compute_normal(&A, &B, &C);
     while (!normal.r)
@@ -4415,7 +4411,7 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
             	// cout << "nullptr bond." << endl;
                 continue;
             }
-            if (!b2->atom2)
+            if (!b2->get_atom2())
             {
             	// cout << "nullptr atom2." << endl;
                 b2=0;
@@ -4423,7 +4419,7 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
             }
             for (j=0; j<ringsz; j++)
             {
-            	if (ring_members[j] == b2->atom2)
+            	if (ring_members[j] == b2->get_atom2())
                 {
             		// cout << "atom2 is part of the ring." << endl;
                     b2 = 0;
@@ -4432,13 +4428,13 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
             }
             if (b2) break;
         }
-        if (b2 && b2->atom2)
+        if (b2 && b2->get_atom2())
         {
-        	// cout << "found " << b2->atom2->name << endl;
+        	// cout << "found " << b2->get_atom2()->name << endl;
             Point ptnew = ring_members[l]->get_location().subtract(ringcen);
-            ptnew.scale(InteratomicForce::covalent_bond_radius(ring_members[l], b2->atom2, b2->cardinality));
+            ptnew.scale(InteratomicForce::covalent_bond_radius(ring_members[l], b2->get_atom2(), b2->cardinality));
             ptnew = ring_members[l]->get_location().add(ptnew);
-            b2->atom2->move_assembly(&ptnew, ring_members[l]);
+            b2->get_atom2()->move_assembly(&ptnew, ring_members[l]);
         }
     }
 }
@@ -4477,14 +4473,14 @@ float Molecule::close_loop(Atom** path, float lcard)
 
         for (j=0; j<geo; j++)
         {
-            if (b[j] && b[j]->atom2
+            if (b[j] && b[j]->get_atom2()
                     &&
                     (	b[j]->can_rotate
                         ||
                         b[j]->can_flip
                     )
                     &&
-                    strcmp(b[j]->atom2->name, "N")
+                    strcmp(b[j]->get_atom2()->name, "N")
                ) rotables[k++] = b[j];
         }
 
@@ -4519,18 +4515,18 @@ float Molecule::close_loop(Atom** path, float lcard)
     {
         for (i=0; rotables[i]; i++)
         {
-            float rr = rotables[i]->atom1->get_location().get_3d_distance(rotables[i]->atom2->get_location());
+            float rr = rotables[i]->get_atom1()->get_location().get_3d_distance(rotables[i]->get_atom2()->get_location());
 
             if (fabs(rr-bond_length) > 0.01)
             {
-                Point aloc = rotables[i]->atom1->get_location();
-                Point bloc = rotables[i]->atom2->get_location();
+                Point aloc = rotables[i]->get_atom1()->get_location();
+                Point bloc = rotables[i]->get_atom1()->get_location();
 
                 bloc = bloc.subtract(aloc);
                 bloc.scale(bond_length);
                 bloc = bloc.add(aloc);
 
-                rotables[i]->atom2->move(bloc);
+                rotables[i]->get_atom2()->move(bloc);
             }
 
             // issue_5
@@ -4894,7 +4890,7 @@ float Molecule::get_atom_error(int i, LocatedVector* best_lv, bool hemi)
     // Get the atom's zero-index bonded atom. Call it atom2 (because why not overuse a foolish pun?).
     atoms[i]->fetch_bonds(b);
     if (!b[0]) return error;
-    atom2 = b[0]->atom2;
+    atom2 = b[0]->get_atom2();
     float card = b[0]->cardinality;
     if (!atom2)
     {
@@ -4951,9 +4947,9 @@ float Molecule::get_atom_error(int i, LocatedVector* best_lv, bool hemi)
                 // Seek optimal bond radii.
                 for (j=1; b[j]; j++)
                 {
-                    if (!b[j]->atom2) continue;
-                    float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->atom2, b[j]->cardinality);
-                    float r = b[j]->atom2->get_location().get_3d_distance(lv.to_point());
+                    if (!b[j]->get_atom2()) continue;
+                    float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->get_atom2(), b[j]->cardinality);
+                    float r = b[j]->get_atom2()->get_location().get_3d_distance(lv.to_point());
 
                     score -= _SANOM_BOND_RAD_WEIGHT * fabs(optimal-r);
                 }
@@ -4987,9 +4983,9 @@ float Molecule::get_atom_error(int i, LocatedVector* best_lv, bool hemi)
 
     for (j=1; b[j]; j++)
     {
-        if (!b[j]->atom2) continue;
-        float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->atom2, b[j]->cardinality);
-        float r = b[j]->atom2->get_location().get_3d_distance(lv.to_point());
+        if (!b[j]->get_atom2()) continue;
+        float optimal = InteratomicForce::covalent_bond_radius(atoms[i], b[j]->get_atom2(), b[j]->cardinality);
+        float r = b[j]->get_atom2()->get_location().get_3d_distance(lv.to_point());
 
         error += _SANOM_BOND_RAD_WEIGHT * fabs(optimal-r);
     }
@@ -5034,7 +5030,7 @@ float Molecule::correct_structure(int iters)
             // Get the atom's zero-index bonded atom. Call it atom2 (because why not overuse a foolish pun?).
             atoms[i]->fetch_bonds(b);
             if (!b[0]) return error;
-            atom2 = b[0]->atom2;
+            atom2 = b[0]->get_atom2();
             if (!atom2) return error;
 
             // TODO
@@ -5184,15 +5180,15 @@ float Molecule::get_atom_bond_length_anomaly(Atom* a, Atom* ignore)
     for (i=0; i<geometry; i++)
     {
         if (!thesebonds[i]) continue;
-        if (thesebonds[i]->atom2)
+        if (thesebonds[i]->get_atom2())
         {
-            if (thesebonds[i]->atom2 == ignore) continue;
-            float optimal = InteratomicForce::covalent_bond_radius(a, thesebonds[i]->atom2, thesebonds[i]->cardinality);
-            float r = a->distance_to(thesebonds[i]->atom2);
+            if (thesebonds[i]->get_atom2() == ignore) continue;
+            float optimal = InteratomicForce::covalent_bond_radius(a, thesebonds[i]->get_atom2(), thesebonds[i]->cardinality);
+            float r = a->distance_to(thesebonds[i]->get_atom2());
             anomaly += pow(1.0+fabs(r-optimal)/optimal, 4)-1;
 
             #if _dbg_molstruct_evolution_bond_lengths
-            if (fabs(r-optimal) > 0.01) cout << "Atoms " << a->name << " and " << thesebonds[i]->atom2->name
+            if (fabs(r-optimal) > 0.01) cout << "Atoms " << a->name << " and " << thesebonds[i]->get_atom2()->name
                 << ", cardinality = " << thesebonds[i]->cardinality
                 << " should be " << optimal << "Å apart, but they're " << r << endl;
             #endif
@@ -5254,7 +5250,7 @@ float Molecule::evolve_structure(int gens, float mr, int ps)
                         Bond* b0 = atoms[j]->get_bond_by_idx(0);
                         if (b0)
                         {
-                            Atom* aparent = b0->atom2;
+                            Atom* aparent = b0->get_atom2();
                             if (aparent)
                             {
                                 optimal = InteratomicForce::covalent_bond_radius(atoms[j], aparent, b0->cardinality);
@@ -5276,7 +5272,7 @@ float Molecule::evolve_structure(int gens, float mr, int ps)
                 Bond* b0 = atoms[j]->get_bond_by_idx(0);
                 if (!b0) continue;
 
-                Atom* aparent = b0->atom2;
+                Atom* aparent = b0->get_atom2();
                 if (!aparent) continue;
 
                 anomaly += get_atom_bond_length_anomaly(aparent, atoms[j]);

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -4380,9 +4380,12 @@ void Molecule::make_coplanar_ring(Atom** ring_members, int ringid)
     normal = compute_normal(&A, &B, &C);
     while (!normal.r)
     {
-    	C.x = frand(-1, 1);
-    	C.y = frand(-1, 1);
-    	C.z = frand(-1, 1);
+    	B.x = frand(-0.01, 0.01);
+    	B.y = frand(-0.01, 0.01);
+    	B.z = frand(-0.01, 0.01);
+    	C.x = frand(-0.01, 0.01);
+    	C.y = frand(-0.01, 0.01);
+    	C.z = frand(-0.01, 0.01);
     	normal = compute_normal(&A, &B, &C);
     }
 

--- a/src/classes/protein.cpp
+++ b/src/classes/protein.cpp
@@ -392,12 +392,12 @@ void Protein::save_pdb(FILE* os, Molecule* lig)
     {
         for (i=0; i<connections.size(); i++)
         {
-            if (!connections[i]->atom || !connections[i]->btom) continue;
+            if (!connections[i]->atom1 || !connections[i]->atom2) continue;
 
             fprintf(os, "CONECT ");
             int a, b;
-            a = connections[i]->atom->pdbidx;
-            b = connections[i]->btom->pdbidx;
+            a = connections[i]->atom1->pdbidx;
+            b = connections[i]->atom2->pdbidx;
 
             if (a < 1000) fprintf(os, " ");
             if (a <  100) fprintf(os, " ");
@@ -921,12 +921,12 @@ int Protein::load_pdb(FILE* is, int rno, char chain)
             residues[i]->clear_cache();
             residues[i]->establish_internal_clash_baseline();
 
-            Atom *atom = residues[i]->get_atom("N"), *btom;
+            Atom *atom = residues[i]->get_atom("N"), *atom2;
             AminoAcid* prev = get_residue(residues[i]->get_residue_no()-1);
             if (prev)
             {
-                btom = prev->get_atom("C");
-                if (atom && btom) atom->bond_to(btom, 1.5);
+                atom2 = prev->get_atom("C");
+                if (atom && atom2) atom->bond_to(atom2, 1.5);
             }
 
             if (!aaptrmin.n || residues[i] < aaptrmin.paa) aaptrmin.paa = residues[i];
@@ -1594,7 +1594,7 @@ Molecule* Protein::metals_as_molecule()
                 {
                     Bond* b = metals[i]->get_bond_by_idx(k++);
                     if (!b) break;
-                    b->btom = mca;
+                    b->atom2 = mca;
                     b->cardinality = 0.5;
                     // cout << metals[i]->name << " coordinates to " << *caa << ":" << mca->name << endl;
                 }
@@ -2579,7 +2579,7 @@ MetalCoord* Protein::coordinate_metal(Atom* metal, int residues, int* resnos, st
                             }   // for n
 
                             /*cout << iter << " " << *aa << ":"
-                            	 << bb[l]->atom->name << "-" << bb[l]->btom->name
+                            	 << bb[l]->atom->name << "-" << bb[l]->atom2->name
                             	 << " " << rad*fiftyseven << "deg, r=" << r
                             	 << ", clash=" << clashes << endl;*/
 
@@ -2636,7 +2636,7 @@ MetalCoord* Protein::coordinate_metal(Atom* metal, int residues, int* resnos, st
                             }   // for n
 
                             /*cout << iter << " " << *aa << ":"
-                            	 << bb[l]->atom->name << "-" << bb[l]->btom->name
+                            	 << bb[l]->atom->name << "-" << bb[l]->atom2->name
                             	 << " " << rad*fiftyseven << "deg, r=" << r
                             	 << ", clash=" << clashes << endl;*/
 

--- a/src/classes/protein.cpp
+++ b/src/classes/protein.cpp
@@ -392,12 +392,12 @@ void Protein::save_pdb(FILE* os, Molecule* lig)
     {
         for (i=0; i<connections.size(); i++)
         {
-            if (!connections[i]->atom1 || !connections[i]->atom2) continue;
+            if (!connections[i]->get_atom1() || !connections[i]->get_atom2()) continue;
 
             fprintf(os, "CONECT ");
             int a, b;
-            a = connections[i]->atom1->pdbidx;
-            b = connections[i]->atom2->pdbidx;
+            a = connections[i]->get_atom1()->pdbidx;
+            b = connections[i]->get_atom2()->pdbidx;
 
             if (a < 1000) fprintf(os, " ");
             if (a <  100) fprintf(os, " ");
@@ -1594,7 +1594,7 @@ Molecule* Protein::metals_as_molecule()
                 {
                     Bond* b = metals[i]->get_bond_by_idx(k++);
                     if (!b) break;
-                    b->atom2 = mca;
+                    b->set_atom2(mca);
                     b->cardinality = 0.5;
                     // cout << metals[i]->name << " coordinates to " << *caa << ":" << mca->name << endl;
                 }
@@ -2579,7 +2579,7 @@ MetalCoord* Protein::coordinate_metal(Atom* metal, int residues, int* resnos, st
                             }   // for n
 
                             /*cout << iter << " " << *aa << ":"
-                            	 << bb[l]->atom->name << "-" << bb[l]->atom2->name
+                            	 << bb[l]->atom->name << "-" << bb[l]->get_atom2()->name
                             	 << " " << rad*fiftyseven << "deg, r=" << r
                             	 << ", clash=" << clashes << endl;*/
 
@@ -2636,7 +2636,7 @@ MetalCoord* Protein::coordinate_metal(Atom* metal, int residues, int* resnos, st
                             }   // for n
 
                             /*cout << iter << " " << *aa << ":"
-                            	 << bb[l]->atom->name << "-" << bb[l]->atom2->name
+                            	 << bb[l]->atom->name << "-" << bb[l]->get_atom2()->name
                             	 << " " << rad*fiftyseven << "deg, r=" << r
                             	 << ", clash=" << clashes << endl;*/
 

--- a/src/molecule_test.cpp
+++ b/src/molecule_test.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
     {
         for (i=0; b[i]; i++)
         {
-            cout << "# Bond " << b[i]->atom1->name << " - " << b[i]->atom2->name << " can rotate." << endl;
+            cout << "# Bond " << b[i]->get_atom1()->name << " - " << b[i]->get_atom2()->name << " can rotate." << endl;
             b[i]->rotate(30.0 * M_PI / 180);
         }
     }

--- a/src/molecule_test.cpp
+++ b/src/molecule_test.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
     {
         for (i=0; b[i]; i++)
         {
-            cout << "# Bond " << b[i]->atom->name << " - " << b[i]->btom->name << " can rotate." << endl;
+            cout << "# Bond " << b[i]->atom1->name << " - " << b[i]->atom2->name << " can rotate." << endl;
             b[i]->rotate(30.0 * M_PI / 180);
         }
     }

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -22,7 +22,7 @@ struct AcvBndRot
     std::string aname;
     std::string bname;
     Atom* atom = nullptr;
-    Atom* btom = nullptr;
+    Atom* atom2 = nullptr;
     Bond* bond = nullptr;
     float theta;
 };
@@ -454,7 +454,7 @@ void iteration_callback(int iter, Molecule** mols)
 
     int ac = ligand->get_atom_count();
     float bbest = 0;
-    Atom *atom, *btom;
+    Atom *atom, *atom2;
 
     float progress = (float)iter / iters;
     // float lsrca = (1.0 - progress) * soft_rock_clash_allowance;
@@ -609,7 +609,7 @@ void iteration_callback(int iter, Molecule** mols)
         {
             atom = ligand->get_atom(i);
             bbest = atom->strongest_bind_energy;
-            btom = atom->strongest_bind_atom;
+            atom2 = atom->strongest_bind_atom;
         }
     }
 
@@ -1421,16 +1421,16 @@ void prepare_acv_bond_rots()
         for (i=0; i<active_bond_rots.size(); i++)
         {
             active_bond_rots[i].atom = protein->get_atom(active_bond_rots[i].resno, active_bond_rots[i].aname.c_str());
-            active_bond_rots[i].btom = protein->get_atom(active_bond_rots[i].resno, active_bond_rots[i].bname.c_str());
+            active_bond_rots[i].atom2 = protein->get_atom(active_bond_rots[i].resno, active_bond_rots[i].bname.c_str());
 
             if (!active_bond_rots[i].atom) cout << "WARNING: " << active_bond_rots[i].resno << ":" << active_bond_rots[i].aname
                 << " not found in protein!" << endl;
-            if (!active_bond_rots[i].btom) cout << "WARNING: " << active_bond_rots[i].resno << ":" << active_bond_rots[i].bname
+            if (!active_bond_rots[i].atom2) cout << "WARNING: " << active_bond_rots[i].resno << ":" << active_bond_rots[i].bname
                 << " not found in protein!" << endl;
 
-            if (active_bond_rots[i].atom && active_bond_rots[i].btom)
+            if (active_bond_rots[i].atom && active_bond_rots[i].atom2)
             {
-                active_bond_rots[i].bond = active_bond_rots[i].atom->get_bond_between(active_bond_rots[i].btom);
+                active_bond_rots[i].bond = active_bond_rots[i].atom->get_bond_between(active_bond_rots[i].atom2);
                 #if _debug_active_bond_rot
                 active_bond_rots[i].bond->echo_on_rotate = true;
                 #endif

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -21,7 +21,7 @@ struct AcvBndRot
     int resno;
     std::string aname;
     std::string bname;
-    Atom* atom = nullptr;
+    Atom* atom1 = nullptr;
     Atom* atom2 = nullptr;
     Bond* bond = nullptr;
     float theta;
@@ -454,7 +454,7 @@ void iteration_callback(int iter, Molecule** mols)
 
     int ac = ligand->get_atom_count();
     float bbest = 0;
-    Atom *atom, *atom2;
+    Atom *atom1, *atom2;
 
     float progress = (float)iter / iters;
     // float lsrca = (1.0 - progress) * soft_rock_clash_allowance;
@@ -607,9 +607,9 @@ void iteration_callback(int iter, Molecule** mols)
     {
         if (ligand->get_atom(i)->strongest_bind_energy > bbest)
         {
-            atom = ligand->get_atom(i);
-            bbest = atom->strongest_bind_energy;
-            atom2 = atom->strongest_bind_atom;
+            atom1 = ligand->get_atom(i);
+            bbest = atom1->strongest_bind_energy;
+            atom2 = atom1->strongest_bind_atom;
         }
     }
 
@@ -1420,17 +1420,17 @@ void prepare_acv_bond_rots()
     {
         for (i=0; i<active_bond_rots.size(); i++)
         {
-            active_bond_rots[i].atom = protein->get_atom(active_bond_rots[i].resno, active_bond_rots[i].aname.c_str());
+            active_bond_rots[i].atom1 = protein->get_atom(active_bond_rots[i].resno, active_bond_rots[i].aname.c_str());
             active_bond_rots[i].atom2 = protein->get_atom(active_bond_rots[i].resno, active_bond_rots[i].bname.c_str());
 
-            if (!active_bond_rots[i].atom) cout << "WARNING: " << active_bond_rots[i].resno << ":" << active_bond_rots[i].aname
+            if (!active_bond_rots[i].atom1) cout << "WARNING: " << active_bond_rots[i].resno << ":" << active_bond_rots[i].aname
                 << " not found in protein!" << endl;
             if (!active_bond_rots[i].atom2) cout << "WARNING: " << active_bond_rots[i].resno << ":" << active_bond_rots[i].bname
                 << " not found in protein!" << endl;
 
-            if (active_bond_rots[i].atom && active_bond_rots[i].atom2)
+            if (active_bond_rots[i].atom1 && active_bond_rots[i].atom2)
             {
-                active_bond_rots[i].bond = active_bond_rots[i].atom->get_bond_between(active_bond_rots[i].atom2);
+                active_bond_rots[i].bond = active_bond_rots[i].atom1->get_bond_between(active_bond_rots[i].atom2);
                 #if _debug_active_bond_rot
                 active_bond_rots[i].bond->echo_on_rotate = true;
                 #endif


### PR DESCRIPTION
Addresses #423 the atom pointers not always pointing to the right atoms.

Also renames the atom pointers of the Bond class to atom1, atom2.