### PR TITLE
Fix prediction failures caused by incorrect predock ligand position.

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,9 +11,9 @@ OBJS=$(OBJDIR)/misc.o $(OBJDIR)/point.o $(OBJDIR)/atom.o $(OBJDIR)/intera.o $(OB
 TESTS=test/point_test test/atom_test test/molecule_test test/pi_stack_test test/mol_assem_test test/aniso_test test/amino_test \
 	  test/group_test_mol test/group_test_res test/protein_test test/backbone_test test/bond_rotation_test test/moiety_test \
 	  test/flexion_test test/histidine_test test/ring_test test/eclipsing_test test/cs_test test/mcoord_test test/vdw_vertex_test \
-	  test/ageo_test test/cavfit_test
+	  test/ageo_test
 APPS=$(BINDIR)/primarydock $(BINDIR)/pepteditor $(BINDIR)/ic \
-	 $(BINDIR)/score_pdb $(BINDIR)/ramachandran $(BINDIR)/ringflip $(BINDIR)/cavity_search
+	 $(BINDIR)/score_pdb $(BINDIR)/ramachandran $(BINDIR)/ringflip $(BINDIR)/cavity_search $(BINDIR)/cavity_fit
 REPORTS=amino_report atom_report aniso_report point_report molecule_report mol_assem_report protein_report motif_report
 all: $(DIRS) \
 	 $(OBJS) \
@@ -155,9 +155,6 @@ test/histidine_test: src/test/histidine_test.cpp $(OBJS)
 test/cs_test: src/test/cs_test.cpp $(OBJS)
 	$(CC) src/test/cs_test.cpp $(OBJS) -o test/cs_test $(CFLAGS)
 
-test/cavfit_test: src/test/cavfit_test.cpp $(OBJS)
-	$(CC) src/test/cavfit_test.cpp $(OBJS) -o test/cavfit_test $(CFLAGS)
-
 test/mcoord_test: src/test/mcoord_test.cpp $(OBJS)
 	$(CC) src/test/mcoord_test.cpp $(OBJS) -o test/mcoord_test $(CFLAGS)
 
@@ -175,6 +172,9 @@ $(BINDIR)/pepteditor: src/interpreter.cpp $(OBJS) $(OBJDIR)/aminoacid.o $(OBJDIR
 
 $(BINDIR)/cavity_search: src/cavity_search.cpp $(OBJS) $(OBJDIR)/cavity.o
 	$(CC) src/cavity_search.cpp $(OBJS) -o $(BINDIR)/cavity_search $(CFLAGS)
+
+$(BINDIR)/cavity_fit: src/cavity_fit.cpp $(OBJS)
+	$(CC) src/cavity_fit.cpp $(OBJS) -o $(BINDIR)/cavity_fit $(CFLAGS)
 
 $(BINDIR)/ic: src/ic.cpp $(OBJS) $(OBJDIR)/protein.o
 	$(CC) src/ic.cpp $(OBJS) -o $(BINDIR)/ic $(CFLAGS)

--- a/src/cavity_fit.cpp
+++ b/src/cavity_fit.cpp
@@ -1,6 +1,6 @@
 
-#include "../classes/search.h"
-#include "../classes/cavity.h"
+#include "classes/search.h"
+#include "classes/cavity.h"
 
 int main(int argc, char** argv)
 {
@@ -11,6 +11,7 @@ int main(int argc, char** argv)
     Cavity cvtys[256];
     int ncvtys = 0;
     bool priorities[256];
+    std::string outfname = "cavfit.pdb";
 
     bool save_tmp_pdbs = false;
 
@@ -83,6 +84,11 @@ int main(int argc, char** argv)
                 else aa = p.get_residue(atoi(argv[i]));
                 if (aa) aa->priority = true;
             }
+        }
+        else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--out"))
+        {
+            i++;
+            outfname = argv[i];
         }
         else cout << "Warning: unknown command argument " << argv[i] << endl;
     }
@@ -181,11 +187,10 @@ int main(int argc, char** argv)
         }
     }
 
-    std::string outf = "cavfit_test.pdb";
-    fp = fopen(outf.c_str(), "w");
+    fp = fopen(outfname.c_str(), "w");
     if (!fp)
     {
-        cout << "FAILED to open output file for writing." << endl;
+        cout << "FAILED to open " << outfname << " for writing." << endl;
         return -3;
     }
     p.save_pdb(fp, &m);

--- a/src/classes/cavity.cpp
+++ b/src/classes/cavity.cpp
@@ -465,7 +465,7 @@ float Cavity::find_best_containment(Molecule* m, bool mbt)
                         else if (inside->polar && fabs(a->is_polar()) > hydrophilicity_cutoff) e = 0.3;
                         else if (inside->thio && a->get_family() == CHALCOGEN && a->get_Z() != 8) e = 0.15;
                         else if (inside->pi && a->is_pi()) e = 0.12;
-                        if (inside->priority) e *= 2;
+                        if (inside->priority) e *= 5;
                         f += e;
                     }
                     atoms_outside_cavity += (1.0-f);

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -397,6 +397,7 @@
 #define _dbg_residue_poses 0
 #define _dbg_rock_pic 0
 #define _dbg_soft 0
+#define _dbg_stays_enforce 1
 #define _DBG_SPACEDOUT 0
 #define _DBG_STEPBYSTEP 0
 #define _DBG_TOOLARGE_DIFFNUMS 0

--- a/src/classes/constants.h
+++ b/src/classes/constants.h
@@ -178,7 +178,7 @@
 #define bb_scooch_threshold_distance 1.5
 #define flexion_selection 1
 #define no_zero_flexions 1
-#define flexion_probability_multiplier 0.3
+#define flexion_probability_multiplier 1.0
 #define ignore_invalid_partial 1
 #define use_best_binding_iteration 0
 #define compute_missed_connections 1
@@ -397,7 +397,7 @@
 #define _dbg_residue_poses 0
 #define _dbg_rock_pic 0
 #define _dbg_soft 0
-#define _dbg_stays_enforce 1
+#define _dbg_stays_enforce 0
 #define _DBG_SPACEDOUT 0
 #define _DBG_STEPBYSTEP 0
 #define _DBG_TOOLARGE_DIFFNUMS 0

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -2911,7 +2911,7 @@ void Molecule::enforce_stays(float amt)
     Rotation rot = align_points_3d(stay_close_mine->get_location(), stay_close_other->get_location(), get_barycenter());
     LocatedVector lv = rot.v;
     lv.origin = get_barycenter();
-    rotate(lv, rot.a*amt);
+    rotate(lv, fmin(fabs(rot.a), hexagonal)*sgn(rot.a)*amt);
 
     SCoord movamt = stay_close_other->get_location().subtract(stay_close_mine->get_location());
     // cout << stay_close_mine->name << " - " << stay_close_other->residue << ":" << stay_close_other->name << " = " << movamt << endl;
@@ -2924,9 +2924,11 @@ void Molecule::enforce_stays(float amt)
     movability = MOV_ALL;
     move(movamt);
     movability = wasmov;
-    movamt = stay_close_other->get_location().subtract(stay_close_mine->get_location());
-    // cout << stay_close_mine->name << " - " << stay_close_other->residue << ":" << stay_close_other->name << " = " << movamt << endl << endl;
 
+    #if _dbg_stays_enforce
+    movamt = stay_close_other->get_location().subtract(stay_close_mine->get_location());
+    cout << stay_close_mine->name << " - " << stay_close_other->residue << ":" << stay_close_other->name << " = " << movamt << endl << endl;
+    #endif
 }
 
 Interaction Molecule::get_intermol_binding(Molecule* ligand, bool subtract_clashes)

--- a/src/classes/search.cpp
+++ b/src/classes/search.cpp
@@ -13,7 +13,7 @@ AminoAcid* cs_res[MAX_CS_RES];
 intera_type cs_bt[MAX_CS_RES];
 AtomGroup* cs_lag[MAX_CS_RES];
 int cs_res_qty = 0;
-int cs_idx = 0;
+int cs_idx = -1;
 bool Search::any_resnos_priority = false;
 
 void Search::do_tumble_spheres(Protein* protein, Molecule* ligand, Point l_pocket_cen)
@@ -499,6 +499,7 @@ int Search::choose_cs_pair(Protein* protein, Molecule* ligand)
         cs_res[l] = protein->get_residue(cs_res[l]->get_residue_no());
         if (cs_res[l]->priority) any_resnos_priority = true;
         cs_lag[l]->update_atom_pointers(ligand);
+        if (cs_bt[l] == ionic) require_ionic = true;
     }
 
     // Choose a residue-type-group combination, randomly but weighted by binding energy of binding type.

--- a/src/primarydock.cpp
+++ b/src/primarydock.cpp
@@ -545,7 +545,7 @@ void iteration_callback(int iter, Molecule** mols)
     int i, j, l, n;
     float f = 0;
 
-    if (pdpst == pst_constrained)
+    if (cs_idx >= 0)
     {
         Point resca = cs_res[cs_idx]->get_CA_location();
         Point agcen = cs_lag[cs_idx]->get_center();
@@ -595,7 +595,7 @@ void iteration_callback(int iter, Molecule** mols)
 
         if (flex
             // && iter < 5
-            && (lf < -10 || lf < 0.1 * ptnl || (lc > 0 && lf < 5))
+            && (lc > 10 || lf < 0.3 * ptnl || (lc > 0 && lf < 5))
             && mols[l]->movability == MOV_FLXDESEL
             && lres
             && frand(0,1) < flexion_probability_multiplier * prob
@@ -2932,7 +2932,7 @@ _try_again:
                     bestp.copy_state(ligand);
                     for (l=0; l<ncvtys; l++)
                     {
-                        float ctainmt = cvtys[l].find_best_containment(ligand, true) * frand(0.5, 1);
+                        float ctainmt = cvtys[l].find_best_containment(ligand, true); // * frand(0.5, 1);
                         if (!l || ctainmt > bestc)
                         {
                             bestp.copy_state(ligand);


### PR DESCRIPTION
Corrects the position of the ligand prior to dock iterations. This will fix prediction failures such as OR51E1 - pelargonic acid which have been failing under the new cavity based docking due to placing the carboxyl group away from Arg264(6.59) and the end of the hydrophobic tail deep inside the receptor instead of near Ala206(5.46).